### PR TITLE
Upload test artifacts

### DIFF
--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -72,7 +72,12 @@ jobs:
       
       - uses: actions/upload-artifact@v3
         with:
+          name: content_pack_${{ matrix.python_version }}_${{ matrix.operating_system }}
+          path: |
+            my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz
+      
+      - uses: actions/upload-artifact@v3
+        with:
           name: test_results_${{ matrix.python_version }}_${{ matrix.operating_system }}
           path: |
             my_splunk_content_pack/test_results/results.yml
-            my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz

--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -47,25 +47,32 @@ jobs:
       - name: Install contentctl and activate the shell
         run: |
           poetry install --no-interaction
-          mkdir my_demo_app
+          mkdir my_splunk_content_pack
 
       - name: Run contentctl init
         run: |
-          cd my_demo_app
+          cd my_splunk_content_pack
           poetry run contentctl init
 
       - name: Run contentctl validate
         run: |
-          cd my_demo_app
+          cd my_splunk_content_pack
           poetry run contentctl validate
 
       - name: Run contentctl build
         run: |
-          cd my_demo_app
+          cd my_splunk_content_pack
           poetry run contentctl build
 
       #Do not pause on a failed detection
       - name: Run contentctl test
         run: |
-          cd my_demo_app
+          cd my_splunk_content_pack
           poetry run contentctl test
+      
+      - uses: actions/upload-artifact@v3
+        with:
+          name: test_results_${{ matrix.python_version }}_${{ matrix.operating_system }}
+          path: |
+            my_splunk_content_pack/test_results/results.yml
+            my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz

--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -73,16 +73,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: content_pack_${{ matrix.python_version }}_${{ matrix.operating_system }}
-          path: my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz
+          path: |
+            my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz
+            my_splunk_content_pack/test_results/summary.yml
       
-      - name: show files
-        run: |
-          pwd
-          ls -lahR
-          cd my_splunk_content_pack
-          ls -lahR
-          cd test_results
-      - uses: actions/upload-artifact@v3
-        with:
-          name: test_results_${{ matrix.python_version }}_${{ matrix.operating_system }}
-          path: my_splunk_content_pack/test_results/results.yml

--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -68,16 +68,21 @@ jobs:
       - name: Run contentctl test
         run: |
           cd my_splunk_content_pack
-          poetry run contentctl test
+          poetry run contentctl test --unattended
       
       - uses: actions/upload-artifact@v3
         with:
           name: content_pack_${{ matrix.python_version }}_${{ matrix.operating_system }}
-          path: |
-            my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz
+          path: my_splunk_content_pack/dist/my_splunk_content_pack.tar.gz
       
+      - name: show files
+        run: |
+          pwd
+          ls -lahR
+          cd my_splunk_content_pack
+          ls -lahR
+          cd test_results
       - uses: actions/upload-artifact@v3
         with:
           name: test_results_${{ matrix.python_version }}_${{ matrix.operating_system }}
-          path: |
-            my_splunk_content_pack/test_results/results.yml
+          path: my_splunk_content_pack/test_results/results.yml


### PR DESCRIPTION
A number of updates to the contentctl install/init/validate/test 
workflow allow it to run "unattended" in CI/CD contexts better
(not block/pause on a failure), reduce stdout/stderr output,
and upload artifacts on test completion.  This also serves
as a good demo for users of how to upload artifacts
after test completion when running contentctl on their 
own content.