### PR TITLE
Changes to support multiple test schedules

### DIFF
--- a/contentctl/input/detection_builder.py
+++ b/contentctl/input/detection_builder.py
@@ -3,7 +3,7 @@ import re
 import os
 
 from pydantic import ValidationError
-
+from copy import deepcopy
 from contentctl.input.yml_reader import YmlReader
 from contentctl.objects.detection import Detection
 from contentctl.objects.security_content_object import SecurityContentObject
@@ -11,113 +11,173 @@ from contentctl.objects.macro import Macro
 from contentctl.objects.mitre_attack_enrichment import MitreAttackEnrichment
 from contentctl.enrichments.cve_enrichment import CveEnrichment
 from contentctl.enrichments.splunk_app_enrichment import SplunkAppEnrichment
-from contentctl.objects.config import ConfigDetectionConfiguration
+from contentctl.objects.config import ConfigDetectionConfiguration, ConfigScheduling
 
 
-class DetectionBuilder():
-    security_content_obj : SecurityContentObject
-
+class DetectionBuilder:
+    security_content_obj: SecurityContentObject
 
     def setObject(self, path: str) -> None:
         yml_dict = YmlReader.load_file(path)
         yml_dict["tags"]["name"] = yml_dict["name"]
         self.security_content_obj = Detection.parse_obj(yml_dict)
-        self.security_content_obj.source = os.path.split(os.path.dirname(self.security_content_obj.file_path))[-1]      
+        self.security_content_obj.source = os.path.split(
+            os.path.dirname(self.security_content_obj.file_path)
+        )[-1]
 
-
-    def addDeployment(self, detection_configuration: ConfigDetectionConfiguration) -> None:
+    def addDeployment(
+        self, detection_configuration: ConfigDetectionConfiguration
+    ) -> None:
         if self.security_content_obj:
-            self.security_content_obj.deployment = detection_configuration
+            new_detection_schedule: ConfigScheduling = None
 
+            possible_schedules = [
+                schedule.name for schedule in detection_configuration.scheduling
+            ]
+
+            matched_schedules = list(
+                filter(
+                    lambda schedule: schedule.name
+                    == self.security_content_obj.scheduling,
+                    detection_configuration.scheduling,
+                )
+            )
+
+            if len(matched_schedules) == 0:
+                raise ValidationError(
+                    f"Failed to find a schedule named {self.security_content_obj.scheduling}. Possible schedule names are {possible_schedules}",
+                )
+            elif len(matched_schedules) == 1:
+                new_detection_schedule = matched_schedules[0]
+            elif len(matched_schedules) > 1:
+                raise ValidationError(
+                    f"Found more than one schedule with the name {self.security_content_obj.scheduling}. Possible schedule names are {possible_schedules}"
+                )
+
+            new_detection_configuration = deepcopy(detection_configuration)
+            new_detection_configuration.scheduling = [new_detection_schedule]
+            print(new_detection_configuration.scheduling)
+            self.security_content_obj.deployment = new_detection_configuration
 
     def addRBA(self) -> None:
         if self.security_content_obj:
             risk_objects = []
-            risk_object_user_types = {'user', 'username', 'email address'}
-            risk_object_system_types = {'device', 'endpoint', 'hostname', 'ip address'}
+            risk_object_user_types = {"user", "username", "email address"}
+            risk_object_system_types = {"device", "endpoint", "hostname", "ip address"}
 
-            if hasattr(self.security_content_obj.tags, 'observable') and hasattr(self.security_content_obj.tags, 'risk_score'):
+            if hasattr(self.security_content_obj.tags, "observable") and hasattr(
+                self.security_content_obj.tags, "risk_score"
+            ):
                 for entity in self.security_content_obj.tags.observable:
                     risk_object = dict()
-                    if entity['type'].lower() in risk_object_user_types:
-                        for r in entity['role']:
-                            if 'attacker' == r.lower() or 'victim' ==r.lower():
-                                risk_object['risk_object_type'] = 'user'
-                                risk_object['risk_object_field'] = entity['name']
-                                risk_object['risk_score'] = self.security_content_obj.tags.risk_score
+                    if entity["type"].lower() in risk_object_user_types:
+                        for r in entity["role"]:
+                            if "attacker" == r.lower() or "victim" == r.lower():
+                                risk_object["risk_object_type"] = "user"
+                                risk_object["risk_object_field"] = entity["name"]
+                                risk_object[
+                                    "risk_score"
+                                ] = self.security_content_obj.tags.risk_score
                                 risk_objects.append(risk_object)
 
-                    elif entity['type'].lower() in risk_object_system_types:
-                        for r in entity['role']:
-                            if 'attacker' == r.lower() or 'victim' ==r.lower():
-                                risk_object['risk_object_type'] = 'system'
-                                risk_object['risk_object_field'] = entity['name']
-                                risk_object['risk_score'] = self.security_content_obj.tags.risk_score
+                    elif entity["type"].lower() in risk_object_system_types:
+                        for r in entity["role"]:
+                            if "attacker" == r.lower() or "victim" == r.lower():
+                                risk_object["risk_object_type"] = "system"
+                                risk_object["risk_object_field"] = entity["name"]
+                                risk_object[
+                                    "risk_score"
+                                ] = self.security_content_obj.tags.risk_score
                                 risk_objects.append(risk_object)
                     else:
-                        risk_object['threat_object_field'] = entity['name']
-                        risk_object['threat_object_type'] = entity['type'].lower()
+                        risk_object["threat_object_field"] = entity["name"]
+                        risk_object["threat_object_type"] = entity["type"].lower()
                         risk_objects.append(risk_object)
                         continue
 
             if self.security_content_obj.tags.risk_score >= 80:
-                self.security_content_obj.tags.risk_severity = 'high'
-            elif (self.security_content_obj.tags.risk_score >= 50 and self.security_content_obj.tags.risk_score <= 79):
-                self.security_content_obj.tags.risk_severity = 'medium'
+                self.security_content_obj.tags.risk_severity = "high"
+            elif (
+                self.security_content_obj.tags.risk_score >= 50
+                and self.security_content_obj.tags.risk_score <= 79
+            ):
+                self.security_content_obj.tags.risk_severity = "medium"
             else:
-                self.security_content_obj.tags.risk_severity = 'low'
+                self.security_content_obj.tags.risk_severity = "low"
 
             self.security_content_obj.risk = risk_objects
-
 
     def addProvidingTechnologies(self) -> None:
         if self.security_content_obj:
             # if self.security_content_obj.tags.supported_tas:
-                if 'Endpoint' in self.security_content_obj.datamodel:
-                    self.security_content_obj.providing_technologies = ["Sysmon", "Microsoft Windows","Carbon Black Response","CrowdStrike Falcon", "Symantec Endpoint Protection"]
-                if "`cloudtrail`" in str(self.security_content_obj.search):
-                    self.security_content_obj.providing_technologies = ["Amazon Web Services - Cloudtrail"]
-                if '`wineventlog_security`' in self.security_content_obj.search or '`powershell`' in self.security_content_obj.search:
-                    self.security_content_obj.providing_technologies = ["Microsoft Windows"]
+            if "Endpoint" in self.security_content_obj.datamodel:
+                self.security_content_obj.providing_technologies = [
+                    "Sysmon",
+                    "Microsoft Windows",
+                    "Carbon Black Response",
+                    "CrowdStrike Falcon",
+                    "Symantec Endpoint Protection",
+                ]
+            if "`cloudtrail`" in str(self.security_content_obj.search):
+                self.security_content_obj.providing_technologies = [
+                    "Amazon Web Services - Cloudtrail"
+                ]
+            if (
+                "`wineventlog_security`" in self.security_content_obj.search
+                or "`powershell`" in self.security_content_obj.search
+            ):
+                self.security_content_obj.providing_technologies = ["Microsoft Windows"]
 
-    
     def addNesFields(self) -> None:
         if self.security_content_obj:
             if self.security_content_obj.deployment:
                 if self.security_content_obj.deployment.notable:
-                    nes_fields = ",".join(list(self.security_content_obj.deployment.notable.nes_fields))
+                    nes_fields = ",".join(
+                        list(self.security_content_obj.deployment.notable.nes_fields)
+                    )
                     self.security_content_obj.nes_fields = nes_fields
-                    
 
     def addMappings(self) -> None:
         if self.security_content_obj:
-            keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist']
+            keys = ["mitre_attack", "kill_chain_phases", "cis20", "nist"]
             mappings = {}
             for key in keys:
-                if key == 'mitre_attack':
-                    if getattr(self.security_content_obj.tags, 'mitre_attack_id'):
-                        mappings[key] = getattr(self.security_content_obj.tags, 'mitre_attack_id')
+                if key == "mitre_attack":
+                    if getattr(self.security_content_obj.tags, "mitre_attack_id"):
+                        mappings[key] = getattr(
+                            self.security_content_obj.tags, "mitre_attack_id"
+                        )
                 elif getattr(self.security_content_obj.tags, key):
                     mappings[key] = getattr(self.security_content_obj.tags, key)
             self.security_content_obj.mappings = mappings
 
-
     def addAnnotations(self) -> None:
         if self.security_content_obj:
             annotations = {}
-            annotation_keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist', 
-                'analytic_story', 'observable', 'context', 'impact', 'confidence', 'cve']
+            annotation_keys = [
+                "mitre_attack",
+                "kill_chain_phases",
+                "cis20",
+                "nist",
+                "analytic_story",
+                "observable",
+                "context",
+                "impact",
+                "confidence",
+                "cve",
+            ]
             for key in annotation_keys:
-                if key == 'mitre_attack':
-                    if getattr(self.security_content_obj.tags, 'mitre_attack_id'):
-                        annotations[key] = getattr(self.security_content_obj.tags, 'mitre_attack_id')
+                if key == "mitre_attack":
+                    if getattr(self.security_content_obj.tags, "mitre_attack_id"):
+                        annotations[key] = getattr(
+                            self.security_content_obj.tags, "mitre_attack_id"
+                        )
                 try:
                     if getattr(self.security_content_obj.tags, key):
                         annotations[key] = getattr(self.security_content_obj.tags, key)
                 except AttributeError as e:
                     continue
-            self.security_content_obj.annotations = annotations    
-
+            self.security_content_obj.annotations = annotations
 
     def addPlaybook(self, playbooks: list) -> None:
         if self.security_content_obj:
@@ -130,7 +190,6 @@ class DetectionBuilder():
 
             self.security_content_obj.playbooks = matched_playbooks
 
-
     def addBaseline(self, baselines: list) -> None:
         if self.security_content_obj:
             matched_baselines = []
@@ -141,50 +200,63 @@ class DetectionBuilder():
 
             self.security_content_obj.baselines = matched_baselines
 
-
     def addUnitTest(self, tests: list) -> None:
         if self.security_content_obj:
             for test in tests:
                 if test.name == f"{self.security_content_obj.name} Unit Test":
                     self.security_content_obj.test = test
                     return
-            if self.security_content_obj.type not in ["Correlation"] and \
-               self.security_content_obj.deprecated == False and \
-               self.security_content_obj.experimental == False:
-                #raise(Exception(f"No tests found found {self.security_content_obj.file_path}"))
+            if (
+                self.security_content_obj.type not in ["Correlation"]
+                and self.security_content_obj.deprecated == False
+                and self.security_content_obj.experimental == False
+            ):
+                # raise(Exception(f"No tests found found {self.security_content_obj.file_path}"))
                 print(f"No tests found found {self.security_content_obj.file_path}")
             return None
-
-
 
     def addMitreAttackEnrichment(self, attack_enrichment: dict) -> None:
         if self.security_content_obj:
             if attack_enrichment:
                 if self.security_content_obj.tags.mitre_attack_id:
                     self.security_content_obj.tags.mitre_attack_enrichments = []
-                    for mitre_attack_id in self.security_content_obj.tags.mitre_attack_id:
+                    for (
+                        mitre_attack_id
+                    ) in self.security_content_obj.tags.mitre_attack_id:
                         if mitre_attack_id in attack_enrichment:
                             mitre_attack_enrichment = MitreAttackEnrichment(
-                                mitre_attack_id = mitre_attack_id, 
-                                mitre_attack_technique = attack_enrichment[mitre_attack_id]["technique"], 
-                                mitre_attack_tactics = sorted(attack_enrichment[mitre_attack_id]["tactics"]), 
-                                mitre_attack_groups = sorted(attack_enrichment[mitre_attack_id]["groups"])
+                                mitre_attack_id=mitre_attack_id,
+                                mitre_attack_technique=attack_enrichment[
+                                    mitre_attack_id
+                                ]["technique"],
+                                mitre_attack_tactics=sorted(
+                                    attack_enrichment[mitre_attack_id]["tactics"]
+                                ),
+                                mitre_attack_groups=sorted(
+                                    attack_enrichment[mitre_attack_id]["groups"]
+                                ),
                             )
-                            self.security_content_obj.tags.mitre_attack_enrichments.append(mitre_attack_enrichment)
+                            self.security_content_obj.tags.mitre_attack_enrichments.append(
+                                mitre_attack_enrichment
+                            )
                         else:
-                            #print("mitre_attack_id " + mitre_attack_id + " doesn't exist for detecction " + self.security_content_obj.name)
-                            raise ValueError("mitre_attack_id " + mitre_attack_id + " doesn't exist for detection " + self.security_content_obj.name)
-
+                            # print("mitre_attack_id " + mitre_attack_id + " doesn't exist for detecction " + self.security_content_obj.name)
+                            raise ValueError(
+                                "mitre_attack_id "
+                                + mitre_attack_id
+                                + " doesn't exist for detection "
+                                + self.security_content_obj.name
+                            )
 
     def addMacros(self, macros: list) -> None:
         if self.security_content_obj:
-            macros_found = re.findall(r'`([^\s]+)`', self.security_content_obj.search)
+            macros_found = re.findall(r"`([^\s]+)`", self.security_content_obj.search)
             macros_filtered = set()
             self.security_content_obj.macros = []
 
             for macro in macros_found:
-                if not '_filter' in macro and not 'drop_dm_object_name' in macro:
-                    start = macro.find('(')
+                if not "_filter" in macro and not "drop_dm_object_name" in macro:
+                    start = macro.find("(")
                     if start != -1:
                         macros_filtered.add(macro[:start])
                     else:
@@ -195,39 +267,54 @@ class DetectionBuilder():
                     if macro_name == macro.name:
                         self.security_content_obj.macros.append(macro)
 
-            name = self.security_content_obj.name.replace(' ', '_').replace('-', '_').replace('.', '_').replace('/', '_').lower() + '_filter'
-            macro = Macro(name=name, definition='search *', description='Update this macro to limit the output results to filter out false positives.')
-            
-            self.security_content_obj.macros.append(macro)
+            name = (
+                self.security_content_obj.name.replace(" ", "_")
+                .replace("-", "_")
+                .replace(".", "_")
+                .replace("/", "_")
+                .lower()
+                + "_filter"
+            )
+            macro = Macro(
+                name=name,
+                definition="search *",
+                description="Update this macro to limit the output results to filter out false positives.",
+            )
 
+            self.security_content_obj.macros.append(macro)
 
     def addLookups(self, lookups: list) -> None:
         if self.security_content_obj:
-            lookups_found = re.findall(r'lookup (?:update=true)?(?:append=t)?\s*([^\s]*)', self.security_content_obj.search)
+            lookups_found = re.findall(
+                r"lookup (?:update=true)?(?:append=t)?\s*([^\s]*)",
+                self.security_content_obj.search,
+            )
             self.security_content_obj.lookups = []
             for lookup_name in lookups_found:
                 for lookup in lookups:
                     if lookup.name == lookup_name:
                         self.security_content_obj.lookups.append(lookup)
 
-
     def addCve(self) -> None:
         if self.security_content_obj:
             self.security_content_obj.cve_enrichment = []
             if self.security_content_obj.tags.cve:
                 for cve in self.security_content_obj.tags.cve:
-                    self.security_content_obj.cve_enrichment.append(CveEnrichment.enrich_cve(cve))
+                    self.security_content_obj.cve_enrichment.append(
+                        CveEnrichment.enrich_cve(cve)
+                    )
 
     def addSplunkApp(self) -> None:
         if self.security_content_obj:
             self.security_content_obj.splunk_app_enrichment = []
             if self.security_content_obj.tags.supported_tas:
                 for splunk_app in self.security_content_obj.tags.supported_tas:
-                    self.security_content_obj.splunk_app_enrichment.append(SplunkAppEnrichment.enrich_splunk_app(splunk_app))
+                    self.security_content_obj.splunk_app_enrichment.append(
+                        SplunkAppEnrichment.enrich_splunk_app(splunk_app)
+                    )
 
     def reset(self) -> None:
         self.security_content_obj = None
-
 
     def getObject(self) -> SecurityContentObject:
         return self.security_content_obj

--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from pydantic import ValidationError
 
 
-
 from contentctl.objects.detection import Detection
 from contentctl.objects.story import Story
 from contentctl.objects.baseline import Baseline
@@ -31,7 +30,6 @@ from contentctl.objects.config import Config
 from contentctl.objects.config import Config
 
 
-
 @dataclass(frozen=True)
 class DirectorInputDto:
     input_path: str
@@ -41,17 +39,17 @@ class DirectorInputDto:
 
 @dataclass()
 class DirectorOutputDto:
-     detections: list[Detection]
-     stories: list[Story]
-     baselines: list[Baseline]
-     investigations: list[Investigation]
-     playbooks: list[Playbook]
-     macros: list[Macro]
-     lookups: list[Lookup]
-     tests: list[UnitTest]
+    detections: list[Detection]
+    stories: list[Story]
+    baselines: list[Baseline]
+    investigations: list[Investigation]
+    playbooks: list[Playbook]
+    macros: list[Macro]
+    lookups: list[Lookup]
+    tests: list[UnitTest]
 
 
-class Director():
+class Director:
     input_dto: DirectorInputDto
     output_dto: DirectorOutputDto
     basic_builder: BasicBuilder
@@ -63,19 +61,18 @@ class Director():
     attack_enrichment: dict
     config: Config
 
-
     def __init__(self, output_dto: DirectorOutputDto) -> None:
         self.output_dto = output_dto
         self.attack_enrichment = dict()
 
-
     def execute(self, input_dto: DirectorInputDto) -> None:
         self.input_dto = input_dto
-        
-        
+
         if self.input_dto.config.enrichments.attack_enrichment:
-            self.attack_enrichment = AttackEnrichment.get_attack_lookup(self.input_dto.input_path)
-        
+            self.attack_enrichment = AttackEnrichment.get_attack_lookup(
+                self.input_dto.input_path
+            )
+
         self.basic_builder = BasicBuilder()
         self.playbook_builder = PlaybookBuilder(self.input_dto.input_path)
         self.baseline_builder = BaselineBuilder()
@@ -83,7 +80,10 @@ class Director():
         self.story_builder = StoryBuilder()
         self.detection_builder = DetectionBuilder()
 
-        if self.input_dto.product == SecurityContentProduct.splunk_app or self.input_dto.product == SecurityContentProduct.json_objects:
+        if (
+            self.input_dto.product == SecurityContentProduct.splunk_app
+            or self.input_dto.product == SecurityContentProduct.json_objects
+        ):
             self.createSecurityContent(SecurityContentType.unit_tests)
             self.createSecurityContent(SecurityContentType.lookups)
             self.createSecurityContent(SecurityContentType.macros)
@@ -96,98 +96,116 @@ class Director():
         elif self.input_dto.product == SecurityContentProduct.ba_objects:
             self.createSecurityContent(SecurityContentType.unit_tests)
             self.createSecurityContent(SecurityContentType.detections)
-            
 
     def createSecurityContent(self, type: SecurityContentType) -> None:
         objects = []
         if type == SecurityContentType.unit_tests:
-            files = Utils.get_all_yml_files_from_directory(os.path.join(self.input_dto.input_path, 'tests'))
+            files = Utils.get_all_yml_files_from_directory(
+                os.path.join(self.input_dto.input_path, "tests")
+            )
         else:
-            files = Utils.get_all_yml_files_from_directory(os.path.join(self.input_dto.input_path, str(type.name)))
+            files = Utils.get_all_yml_files_from_directory(
+                os.path.join(self.input_dto.input_path, str(type.name))
+            )
 
         validation_error_found = False
-                
+
         already_ran = False
         progress_percent = 0
 
-        if self.input_dto.product == SecurityContentProduct.splunk_app or self.input_dto.product == SecurityContentProduct.json_objects:
-            security_content_files = [f for f in files if 'ssa___' not in f]
+        if (
+            self.input_dto.product == SecurityContentProduct.splunk_app
+            or self.input_dto.product == SecurityContentProduct.json_objects
+        ):
+            security_content_files = [f for f in files if "ssa___" not in f]
         elif self.input_dto.product == SecurityContentProduct.ba_objects:
-            security_content_files = [f for f in files if 'ssa___' in f]
+            security_content_files = [f for f in files if "ssa___" in f]
         else:
-            raise(Exception(f"Cannot createSecurityContent for unknown product '{self.input_dto.product}'"))
+            raise (
+                Exception(
+                    f"Cannot createSecurityContent for unknown product '{self.input_dto.product}'"
+                )
+            )
 
-
-        for index,file in enumerate(security_content_files):
-            progress_percent = ((index+1)/len(security_content_files)) * 100
+        for index, file in enumerate(security_content_files):
+            progress_percent = ((index + 1) / len(security_content_files)) * 100
             try:
                 type_string = "UNKNOWN TYPE"
                 if type == SecurityContentType.lookups:
-                        self.constructLookup(self.basic_builder, file)
-                        lookup = self.basic_builder.getObject()
-                        self.output_dto.lookups.append(lookup)
-                
+                    self.constructLookup(self.basic_builder, file)
+                    lookup = self.basic_builder.getObject()
+                    self.output_dto.lookups.append(lookup)
+
                 elif type == SecurityContentType.macros:
-                        self.constructMacro(self.basic_builder, file)
-                        macro = self.basic_builder.getObject()
-                        self.output_dto.macros.append(macro)
-                
+                    self.constructMacro(self.basic_builder, file)
+                    macro = self.basic_builder.getObject()
+                    self.output_dto.macros.append(macro)
+
                 elif type == SecurityContentType.deployments:
-                        self.constructDeployment(self.basic_builder, file)
-                        deployment = self.basic_builder.getObject()
-                        self.output_dto.deployments.append(deployment)
-                
+                    self.constructDeployment(self.basic_builder, file)
+                    deployment = self.basic_builder.getObject()
+                    self.output_dto.deployments.append(deployment)
+
                 elif type == SecurityContentType.playbooks:
-                        self.constructPlaybook(self.playbook_builder, file)
-                        playbook = self.playbook_builder.getObject()
-                        self.output_dto.playbooks.append(playbook)                    
-                
+                    self.constructPlaybook(self.playbook_builder, file)
+                    playbook = self.playbook_builder.getObject()
+                    self.output_dto.playbooks.append(playbook)
+
                 elif type == SecurityContentType.baselines:
-                        type_string = "Baselines"
-                        self.constructBaseline(self.baseline_builder, file)
-                        baseline = self.baseline_builder.getObject()
-                        self.output_dto.baselines.append(baseline)
-                
+                    type_string = "Baselines"
+                    self.constructBaseline(self.baseline_builder, file)
+                    baseline = self.baseline_builder.getObject()
+                    self.output_dto.baselines.append(baseline)
+
                 elif type == SecurityContentType.investigations:
-                        self.constructInvestigation(self.investigation_builder, file)
-                        investigation = self.investigation_builder.getObject()
-                        self.output_dto.investigations.append(investigation)
+                    self.constructInvestigation(self.investigation_builder, file)
+                    investigation = self.investigation_builder.getObject()
+                    self.output_dto.investigations.append(investigation)
 
                 elif type == SecurityContentType.stories:
-                        type_string = "Stories"
-                        self.constructStory(self.story_builder, file)
-                        story = self.story_builder.getObject()
-                        self.output_dto.stories.append(story)
-            
+                    type_string = "Stories"
+                    self.constructStory(self.story_builder, file)
+                    story = self.story_builder.getObject()
+                    self.output_dto.stories.append(story)
+
                 elif type == SecurityContentType.detections:
-                        type_string = "Detections"
-                        self.constructDetection(self.detection_builder, file)
-                        detection = self.detection_builder.getObject()
-                        self.output_dto.detections.append(detection)
-            
+                    type_string = "Detections"
+                    self.constructDetection(self.detection_builder, file)
+                    detection = self.detection_builder.getObject()
+                    self.output_dto.detections.append(detection)
+
                 elif type == SecurityContentType.unit_tests:
-                        self.constructTest(self.basic_builder, file)
-                        test = self.basic_builder.getObject()
-                        self.output_dto.tests.append(test)
+                    self.constructTest(self.basic_builder, file)
+                    test = self.basic_builder.getObject()
+                    self.output_dto.tests.append(test)
 
                 else:
-                        raise Exception(f"Unsupported type: [{type}]")
-                
-                if (sys.stdout.isatty() and sys.stdin.isatty() and sys.stderr.isatty()) or not already_ran:
-                        already_ran = True
-                        print(f"\r{f'{type_string} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...", end="", flush=True)
-            
+                    raise Exception(f"Unsupported type: [{type}]")
+
+                if (
+                    sys.stdout.isatty() and sys.stdin.isatty() and sys.stderr.isatty()
+                ) or not already_ran:
+                    already_ran = True
+                    print(
+                        f"\r{f'{type_string} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...",
+                        end="",
+                        flush=True,
+                    )
+
             except ValidationError as e:
-                print('\nValidation Error for file ' + file)
+                print("\nValidation Error for file " + file)
                 print(e)
                 validation_error_found = True
 
-        print(f"\r{f'{type.name} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...", end="", flush=True)
+        print(
+            f"\r{f'{type.name} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...",
+            end="",
+            flush=True,
+        )
         print("Done!")
 
         if validation_error_found:
             sys.exit(1)
-
 
     def constructDetection(self, builder: DetectionBuilder, file_path: str) -> None:
         builder.reset()
@@ -203,16 +221,15 @@ class Director():
         builder.addUnitTest(self.output_dto.tests)
         builder.addMacros(self.output_dto.macros)
         builder.addLookups(self.output_dto.lookups)
-        
+
         if self.input_dto.config.enrichments.attack_enrichment:
             builder.addMitreAttackEnrichment(self.attack_enrichment)
 
         if self.input_dto.config.enrichments.cve_enrichment:
             builder.addCve()
-    
+
         if self.input_dto.config.enrichments.splunk_app_enrichment:
             builder.addSplunkApp()
-
 
     def constructStory(self, builder: StoryBuilder, file_path: str) -> None:
         builder.reset()
@@ -222,12 +239,10 @@ class Director():
         builder.addBaselines(self.output_dto.baselines)
         builder.addAuthorCompanyName()
 
-
     def constructBaseline(self, builder: BaselineBuilder, file_path: str) -> None:
         builder.reset()
         builder.setObject(file_path)
         builder.addDeployment(self.output_dto.deployments)
-
 
     def constructDeployment(self, builder: BasicBuilder, file_path: str) -> None:
         builder.reset()
@@ -237,24 +252,22 @@ class Director():
         builder.reset()
         builder.setObject(file_path, SecurityContentType.lookups)
 
-
     def constructMacro(self, builder: BasicBuilder, file_path: str) -> None:
         builder.reset()
         builder.setObject(file_path, SecurityContentType.macros)
-
 
     def constructPlaybook(self, builder: PlaybookBuilder, file_path: str) -> None:
         builder.reset()
         builder.setObject(file_path)
         builder.addDetections()
 
-
     def constructTest(self, builder: BasicBuilder, file_path: str) -> None:
         builder.reset()
         builder.setObject(file_path, SecurityContentType.unit_tests)
 
-
-    def constructInvestigation(self, builder: InvestigationBuilder, file_path: str) -> None:
+    def constructInvestigation(
+        self, builder: InvestigationBuilder, file_path: str
+    ) -> None:
         builder.reset()
         builder.setObject(file_path)
         builder.addInputs()

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -7,6 +7,7 @@ class ConfigGlobal(BaseModel):
 
 
 class ConfigScheduling(BaseModel):
+    name: str = "default_schedule"
     cron_schedule: str
     earliest_time: str
     latest_time: str
@@ -43,7 +44,7 @@ class ConfigRba(BaseModel):
 
 
 class ConfigDetectionConfiguration(BaseModel):
-    scheduling: ConfigScheduling
+    scheduling: list[ConfigScheduling] = []
     notable: ConfigNotable = None
     email: ConfigEmail = None
     slack: ConfigSlack = None
@@ -86,8 +87,8 @@ class ConfigBuildBa(BaseModel):
 
 class ConfigBuild(BaseModel):
     splunk_app: ConfigBuildSplunk
-    #json_objects: ConfigBuildJson
-    #ba_objects: ConfigBuildBa
+    # json_objects: ConfigBuildJson
+    # ba_objects: ConfigBuildBa
 
 
 class ConfigEnrichments(BaseModel):
@@ -96,12 +97,10 @@ class ConfigEnrichments(BaseModel):
     splunk_app_enrichment: bool
 
 
-
 class Config(BaseModel):
-    #general: ConfigGlobal
+    # general: ConfigGlobal
     detection_configuration: ConfigDetectionConfiguration
     test: ConfigTest = None
     deploy: ConfigDeploy
     build: ConfigBuild
     enrichments: ConfigEnrichments
-

--- a/contentctl/objects/detection.py
+++ b/contentctl/objects/detection.py
@@ -62,7 +62,7 @@ class Detection(BaseModel, SecurityContentObject):
     source: str = None
     nes_fields: str = None
     providing_technologies: list = None
-
+    scheduling: str = "default_schedule"
     # @validator('name')
     # def name_max_length(cls, v, values):
     #     if len(v) > 67:

--- a/contentctl/output/conf_output.py
+++ b/contentctl/output/conf_output.py
@@ -21,101 +21,168 @@ class ConfOutput:
         self.app_name = config.build.splunk_app.prefix
         self.output_path = os.path.join(input_path, config.build.splunk_app.path)
         Path(self.output_path).mkdir(parents=True, exist_ok=True)
-        template_splunk_app_path = os.path.join(os.path.dirname(__file__), '../templates/splunk_app')
+        template_splunk_app_path = os.path.join(
+            os.path.dirname(__file__), "../templates/splunk_app"
+        )
         shutil.copytree(template_splunk_app_path, self.output_path, dirs_exist_ok=True)
 
-
     def writeHeaders(self) -> None:
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/analyticstories.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/savedsearches.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/collections.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/es_investigations.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/macros.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/transforms.conf'))
-        ConfWriter.writeConfFileHeader(os.path.join(self.output_path, 'default/workflow_actions.conf'))
-
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/analyticstories.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/savedsearches.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/collections.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/es_investigations.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/macros.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/transforms.conf")
+        )
+        ConfWriter.writeConfFileHeader(
+            os.path.join(self.output_path, "default/workflow_actions.conf")
+        )
 
     def writeObjects(self, objects: list, type: SecurityContentType = None) -> None:
         if type == SecurityContentType.detections:
-            ConfWriter.writeConfFile('savedsearches_detections.j2', 
-            os.path.join(self.output_path, 'default/savedsearches.conf'), 
-            objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "savedsearches_detections.j2",
+                os.path.join(self.output_path, "default/savedsearches.conf"),
+                objects,
+                self.app_name,
+            )
 
-            ConfWriter.writeConfFile('analyticstories_detections.j2',
-                os.path.join(self.output_path, 'default/analyticstories.conf'), 
-                objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "analyticstories_detections.j2",
+                os.path.join(self.output_path, "default/analyticstories.conf"),
+                objects,
+                self.app_name,
+            )
 
-            ConfWriter.writeConfFile('macros_detections.j2',
-                os.path.join(self.output_path, 'default/macros.conf'), 
-                objects,self.app_name)
-        
+            ConfWriter.writeConfFile(
+                "macros_detections.j2",
+                os.path.join(self.output_path, "default/macros.conf"),
+                objects,
+                self.app_name,
+            )
+
         elif type == SecurityContentType.stories:
-            ConfWriter.writeConfFile('analyticstories_stories.j2',
-                os.path.join(self.output_path, 'default/analyticstories.conf'), 
-                objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "analyticstories_stories.j2",
+                os.path.join(self.output_path, "default/analyticstories.conf"),
+                objects,
+                self.app_name,
+            )
 
         elif type == SecurityContentType.baselines:
-            ConfWriter.writeConfFile('savedsearches_baselines.j2', 
-                os.path.join(self.output_path, 'default/savedsearches.conf'), 
-                objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "savedsearches_baselines.j2",
+                os.path.join(self.output_path, "default/savedsearches.conf"),
+                objects,
+                self.app_name,
+            )
 
         elif type == SecurityContentType.investigations:
-            ConfWriter.writeConfFile('savedsearches_investigations.j2', 
-                os.path.join(self.output_path, 'default/savedsearches.conf'), 
-                objects,self.app_name)
-            
-            ConfWriter.writeConfFile('analyticstories_investigations.j2', 
-                os.path.join(self.output_path, 'default/analyticstories.conf'), 
-                objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "savedsearches_investigations.j2",
+                os.path.join(self.output_path, "default/savedsearches.conf"),
+                objects,
+                self.app_name,
+            )
+
+            ConfWriter.writeConfFile(
+                "analyticstories_investigations.j2",
+                os.path.join(self.output_path, "default/analyticstories.conf"),
+                objects,
+                self.app_name,
+            )
 
             workbench_panels = []
             for investigation in objects:
                 if investigation.inputs:
-                    response_file_name_xml = investigation.lowercase_name + "___response_task.xml"
+                    response_file_name_xml = (
+                        investigation.lowercase_name + "___response_task.xml"
+                    )
                     workbench_panels.append(investigation)
-                    investigation.search = investigation.search.replace(">","&gt;")
-                    investigation.search = investigation.search.replace("<","&lt;")
-                    ConfWriter.writeConfFileHeaderEmpty(os.path.join(self.output_path, 
-                        'default/data/ui/panels/', str("workbench_panel_" + response_file_name_xml)))
-                    ConfWriter.writeConfFile('panel.j2', 
-                        os.path.join(self.output_path, 
-                        'default/data/ui/panels/', str("workbench_panel_" + response_file_name_xml)),
-                        [investigation.search],self.app_name)
+                    investigation.search = investigation.search.replace(">", "&gt;")
+                    investigation.search = investigation.search.replace("<", "&lt;")
+                    ConfWriter.writeConfFileHeaderEmpty(
+                        os.path.join(
+                            self.output_path,
+                            "default/data/ui/panels/",
+                            str("workbench_panel_" + response_file_name_xml),
+                        )
+                    )
+                    ConfWriter.writeConfFile(
+                        "panel.j2",
+                        os.path.join(
+                            self.output_path,
+                            "default/data/ui/panels/",
+                            str("workbench_panel_" + response_file_name_xml),
+                        ),
+                        [investigation.search],
+                        self.app_name,
+                    )
 
-            ConfWriter.writeConfFile('es_investigations_investigations.j2', 
-                os.path.join(self.output_path, 'default/es_investigations.conf'), 
-                workbench_panels,self.app_name)
+            ConfWriter.writeConfFile(
+                "es_investigations_investigations.j2",
+                os.path.join(self.output_path, "default/es_investigations.conf"),
+                workbench_panels,
+                self.app_name,
+            )
 
-            ConfWriter.writeConfFile('workflow_actions.j2', 
-                os.path.join(self.output_path, 'default/workflow_actions.conf'), 
-                workbench_panels,self.app_name)   
+            ConfWriter.writeConfFile(
+                "workflow_actions.j2",
+                os.path.join(self.output_path, "default/workflow_actions.conf"),
+                workbench_panels,
+                self.app_name,
+            )
 
         elif type == SecurityContentType.lookups:
-            ConfWriter.writeConfFile('collections.j2', 
-                os.path.join(self.output_path, 'default/collections.conf'), 
-                objects,self.app_name)
+            ConfWriter.writeConfFile(
+                "collections.j2",
+                os.path.join(self.output_path, "default/collections.conf"),
+                objects,
+                self.app_name,
+            )
 
-            ConfWriter.writeConfFile('transforms.j2', 
-                os.path.join(self.output_path, 'default/transforms.conf'), 
-                objects,self.app_name)
-
+            ConfWriter.writeConfFile(
+                "transforms.j2",
+                os.path.join(self.output_path, "default/transforms.conf"),
+                objects,
+                self.app_name,
+            )
 
             if self.input_path is None:
-                raise(Exception(f"input_path is required for lookups, but received [{self.input_path}]"))
+                raise (
+                    Exception(
+                        f"input_path is required for lookups, but received [{self.input_path}]"
+                    )
+                )
 
-            files = glob.iglob(os.path.join(self.input_path, 'lookups', '*.csv'))
+            files = glob.iglob(os.path.join(self.input_path, "lookups", "*.csv"))
             for file in files:
                 if os.path.isfile(file):
-                    shutil.copy(file, os.path.join(self.output_path, 'lookups'))
+                    shutil.copy(file, os.path.join(self.output_path, "lookups"))
 
         elif type == SecurityContentType.macros:
-            ConfWriter.writeConfFile('macros.j2', 
-                os.path.join(self.output_path, 'default/macros.conf'), 
-                objects,self.app_name)
-
+            ConfWriter.writeConfFile(
+                "macros.j2",
+                os.path.join(self.output_path, "default/macros.conf"),
+                objects,
+                self.app_name,
+            )
 
     def packageApp(self) -> None:
         name = self.output_path + ".tar.gz"
 
         with tarfile.open(name, "w:gz") as app_archive:
-            app_archive.add(self.output_path, arcname=os.path.basename(self.output_path))
+            app_archive.add(
+                self.output_path, arcname=os.path.basename(self.output_path)
+            )

--- a/contentctl/output/conf_output.py
+++ b/contentctl/output/conf_output.py
@@ -166,10 +166,26 @@ class ConfOutput:
                     )
                 )
 
+            import pathlib
+
+            lookup_folder_path = pathlib.Path(self.output_path) / "lookups"
+            if not lookup_folder_path.is_dir():
+                if lookup_folder_path.exists():
+                    raise Exception(
+                        f"The app lookup path {lookup_folder_path} exists, but it is not a folder"
+                    )
+                else:
+                    lookup_folder_path.mkdir()
+
             files = glob.iglob(os.path.join(self.input_path, "lookups", "*.csv"))
+
             for file in files:
+                file = pathlib.Path(file)
                 if os.path.isfile(file):
-                    shutil.copy(file, os.path.join(self.output_path, "lookups"))
+                    shutil.copy(
+                        file,
+                        os.path.join(self.output_path, "lookups", file.name),
+                    )
 
         elif type == SecurityContentType.macros:
             ConfWriter.writeConfFile(

--- a/contentctl/output/templates/savedsearches_baselines.j2
+++ b/contentctl/output/templates/savedsearches_baselines.j2
@@ -1,5 +1,3 @@
-
-
 ### {{APP_NAME}} BASELINES ###
 
 {% for detection in objects %}
@@ -18,12 +16,12 @@ action.{{APP_NAME|lower}}.analytic_story = {{ detection.tags.analytic_story | to
 action.{{APP_NAME|lower}}.analytic_story = []
 {% endif %}
 action.{{APP_NAME|lower}}.data_models = {{ detection.datamodel | tojson }}
-cron_schedule = {{ detection.deployment.scheduling.cron_schedule }}
+cron_schedule = {{ detection.deployment.scheduling[0].cron_schedule }}
 enableSched = 1
-dispatch.earliest_time = {{ detection.deployment.scheduling.earliest_time }}
-dispatch.latest_time = {{ detection.deployment.scheduling.latest_time }}
-{% if detection.deployment.scheduling.schedule_window is defined %}
-schedule_window = {{ detection.deployment.scheduling.schedule_window }}
+dispatch.earliest_time = {{ detection.deployment.scheduling[0].earliest_time }}
+dispatch.latest_time = {{ detection.deployment.scheduling[0].latest_time }}
+{% if detection.deployment.scheduling[0].schedule_window is defined %}
+schedule_window = {{ detection.deployment.scheduling[0].schedule_window }}
 {% endif %}
 {% if detection.providing_technologies is defined %}
 action.{{APP_NAME|lower}}.providing_technologies = {{ detection.providing_technologies | tojson }}
@@ -46,4 +44,3 @@ search = {{ detection.search }}
 
 {% endif %}
 {% endfor %}
-

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -1,12 +1,15 @@
 ### {{APP_NAME}} DETECTIONS ###
 
 {% for detection in objects %}
-{% if (detection.type == 'TTP' or detection.type == 'Anomaly' or detection.type == 'Hunting' or detection.type == 'Correlation') %}
+{% if (detection.type == 'TTP' or detection.type == 'Anomaly' or detection.type == 'Hunting' or detection.type ==
+'Correlation') %}
 [{{APP_NAME}} - {{ detection.name }} - Rule]
 action.escu = 0
 action.escu.enabled = 1
 {% if detection.deprecated %}
-description = WARNING, this detection has been marked deprecated by the Splunk Threat Research team, this means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
+description = WARNING, this detection has been marked deprecated by the Splunk Threat Research team, this means that it
+will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{
+detection.description }}
 {% else %}
 description = {{ detection.description }}
 {% endif %}
@@ -48,9 +51,9 @@ action.risk.param.verbose = 0
 {% else %}
 action.escu.analytic_story = []
 {% endif %}
-cron_schedule = {{ detection.deployment.scheduling.cron_schedule }}
-dispatch.earliest_time = {{ detection.deployment.scheduling.earliest_time }}
-dispatch.latest_time = {{ detection.deployment.scheduling.latest_time }}
+cron_schedule = {{ detection.deployment.scheduling[0].cron_schedule }}
+dispatch.earliest_time = {{ detection.deployment.scheduling[0].earliest_time }}
+dispatch.latest_time = {{ detection.deployment.scheduling[0].latest_time }}
 action.correlationsearch.enabled = 1
 {% if detection.deprecated %}
 action.correlationsearch.label = {{APP_NAME}} - Deprecated - {{ detection.name }} - Rule
@@ -58,8 +61,8 @@ action.correlationsearch.label = {{APP_NAME}} - Deprecated - {{ detection.name }
 action.correlationsearch.label = {{APP_NAME}} - {{ detection.name }} - Rule
 {% endif %}
 action.correlationsearch.annotations = {{ detection.annotations | tojson }}
-{% if detection.deployment.scheduling.schedule_window is defined %}
-schedule_window = {{ detection.deployment.scheduling.schedule_window }}
+{% if detection.deployment.scheduling[0].schedule_window is defined %}
+schedule_window = {{ detection.deployment.scheduling[0].schedule_window }}
 {% endif %}
 {% if detection.deployment is defined %}
 {% if detection.deployment.notable.rule_title is defined %}
@@ -67,8 +70,10 @@ action.notable = 1
 {% if detection.nes_fields is defined %}
 action.notable.param.nes_fields = {{ detection.nes_fields }}
 {% endif %}
-action.notable.param.rule_description = {{ detection.deployment.notable.rule_description | custom_jinja2_enrichment_filter(detection) }}
-action.notable.param.rule_title = {{ detection.deployment.notable.rule_title | custom_jinja2_enrichment_filter(detection) }}
+action.notable.param.rule_description = {{ detection.deployment.notable.rule_description |
+custom_jinja2_enrichment_filter(detection) }}
+action.notable.param.rule_title = {{ detection.deployment.notable.rule_title |
+custom_jinja2_enrichment_filter(detection) }}
 action.notable.param.security_domain = {{ detection.tags.security_domain }}
 action.notable.param.severity = high
 {% endif %}
@@ -85,11 +90,15 @@ action.slack.param.message = {{ detection.deployment.slack.message | custom_jinj
 {% endif %}
 {% if detection.deployment.phantom.phantom_server is defined %}
 action.sendtophantom = 1
-action.sendtophantom.param._cam_workers = {{ detection.deployment.phantom.cam_workers | custom_jinja2_enrichment_filter(detection) }}
+action.sendtophantom.param._cam_workers = {{ detection.deployment.phantom.cam_workers |
+custom_jinja2_enrichment_filter(detection) }}
 action.sendtophantom.param.label = {{ detection.deployment.phantom.label | custom_jinja2_enrichment_filter(detection) }}
-action.sendtophantom.param.phantom_server = {{ detection.deployment.phantom.phantom_server | custom_jinja2_enrichment_filter(detection) }}
-action.sendtophantom.param.sensitivity = {{ detection.deployment.phantom.sensitivity | custom_jinja2_enrichment_filter(detection) }}
-action.sendtophantom.param.severity = {{ detection.deployment.phantom.severity | custom_jinja2_enrichment_filter(detection) }}
+action.sendtophantom.param.phantom_server = {{ detection.deployment.phantom.phantom_server |
+custom_jinja2_enrichment_filter(detection) }}
+action.sendtophantom.param.sensitivity = {{ detection.deployment.phantom.sensitivity |
+custom_jinja2_enrichment_filter(detection) }}
+action.sendtophantom.param.severity = {{ detection.deployment.phantom.severity |
+custom_jinja2_enrichment_filter(detection) }}
 {% endif %}
 {% endif %}
 alert.digest_mode = 1

--- a/contentctl/templates/contentctl_default.yml
+++ b/contentctl/templates/contentctl_default.yml
@@ -1,9 +1,10 @@
 detection_configuration:
   scheduling:
-    cron_schedule: 0 * * * *
-    earliest_time: -70m@m
-    latest_time: -10m@m
-    schedule_window: auto
+    - name: default_schedule
+      cron_schedule: 0 * * * *
+      earliest_time: -70m@m
+      latest_time: -10m@m
+      schedule_window: auto
   notable:
     rule_description: "%description%"
     rule_title: "%name%"


### PR DESCRIPTION
Allow different schedules (with names) to be declared in
contentctl.yml.  Then, using the field named scheduling in
a detection, choose the schedule for this detection to run.
