### PR TITLE
fix: add platform param to pull and create operations

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
@@ -93,6 +93,7 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
             name=self.get_name(),
             mounts=mounts,
             detach=True,
+            platform="linux/amd64"
         )
 
         return container

--- a/contentctl/objects/test_config.py
+++ b/contentctl/objects/test_config.py
@@ -277,7 +277,7 @@ class TestConfig(BaseModel, extra=Extra.forbid, validate_assignment=True):
                     end="",
                     flush=True,
                 )
-                client.images.pull(v)
+                client.images.pull(v, platform="linux/amd64")
                 print("done")
             except docker.errors.APIError as e:
                 print("error")


### PR DESCRIPTION
Given that we currently dont publish arm packages for splunk, we have to rely on the emulation on apple silicon.

**System:** M1 Max (2021 Macbook Pro)
**MacOS Version:** 13.4 Ventura
- Rosetta2 installed (/usr/sbin/softwareupdate --install-rosetta --agree-to-license)

**Docker for Desktop:** 4.19.0  (Docker Engine: 23.0.5)
- Enabled _Use Rosetta for x86/amd64 emulation on Apple Silicon_  (Features in developmment -> Beta Features)

Using this configuration, I'm able to run `contentctl test` to completion without issues.



#13