### PR TITLE
Allow absent tests for experimental detections

### DIFF
--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -137,9 +137,9 @@ class Detection_Abstract(SecurityContentObject):
     #     # Found everything
     #     return v
 
-    @validator("tests")
+    @validator("tests", always=True)
     def tests_validate(cls, v, values):
-        if values.get("status","") == DetectionStatus.production and not v:
+        if values.get("status","") == DetectionStatus.production.value and not v:
             raise ValueError(
                 "tests value is needed for production detection: " + values["name"]
             )
@@ -153,7 +153,7 @@ class Detection_Abstract(SecurityContentObject):
         return v
     
     def all_tests_successful(self) -> bool:
-        if len(self.tests) == 0 and self.status is DetectionStatus.production:
+        if len(self.tests) == 0 and self.status is DetectionStatus.production.value:
             return False
         for test in self.tests:
             if test.result is None or test.result.success == False:

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -139,7 +139,7 @@ class Detection_Abstract(SecurityContentObject):
 
     @validator("tests")
     def tests_validate(cls, v, values):
-        if values.get("status","") != DetectionStatus.production and not v:
+        if values.get("status","") == DetectionStatus.production and not v:
             raise ValueError(
                 "tests value is needed for production detection: " + values["name"]
             )
@@ -153,7 +153,7 @@ class Detection_Abstract(SecurityContentObject):
         return v
     
     def all_tests_successful(self) -> bool:
-        if len(self.tests) == 0:
+        if len(self.tests) == 0 and self.status is DetectionStatus.production:
             return False
         for test in self.tests:
             if test.result is None or test.result.success == False:


### PR DESCRIPTION
This is consistent with the validation check
that allows no tests if status=experimental