### PR TITLE
Handle stopped containers in testing

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
@@ -41,13 +41,17 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
     def check_for_teardown(self):
 
         try:
-            self.get_docker_client().containers.get(self.get_name())
+            container: docker.models.containers.Container = self.get_docker_client().containers.get(self.get_name())
         except Exception as e:
             if self.sync_obj.terminate is not True:
                 self.pbar.write(
                     f"Error: could not get container [{self.get_name()}]: {str(e)}"
                 )
                 self.sync_obj.terminate = True
+        else:
+            if container.status != 'running':
+                self.sync_obj.terminate = True
+                self.container = None
 
         if self.sync_obj.terminate:
             self.finish()


### PR DESCRIPTION
This means a failed container will no longer hang the test command