### PR TITLE
Allow individual detections to override actions

### DIFF
--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -220,7 +220,7 @@ def doc_gen(args) -> None:
 
 
 def new_content(args) -> None:
-
+    config = start(args)
     if args.type == "detection":
         contentType = SecurityContentType.detections
     elif args.type == "story":
@@ -229,7 +229,7 @@ def new_content(args) -> None:
         print("ERROR: type " + args.type + " not supported")
         sys.exit(1)
 
-    new_content_generator_input_dto = NewContentGeneratorInputDto(type=contentType)
+    new_content_generator_input_dto = NewContentGeneratorInputDto(type=contentType, config=config)
     new_content_input_dto = NewContentInputDto(
         new_content_generator_input_dto, os.path.abspath(args.path)
     )

--- a/contentctl/input/detection_builder.py
+++ b/contentctl/input/detection_builder.py
@@ -33,6 +33,7 @@ class DetectionBuilder():
             else:
                 deployment = detection_configuration.dict() | deployment.dict(exclude_unset=True)
 
+            self.security_content_obj.deployment = deployment
 
     def addRBA(self) -> None:
         if self.security_content_obj:

--- a/contentctl/input/detection_builder.py
+++ b/contentctl/input/detection_builder.py
@@ -31,7 +31,7 @@ class DetectionBuilder():
             if not deployment:
                 deployment = detection_configuration
             else:
-                deployment = detection_configuration.dict() | deployment.dict(exclude_unset=True)
+                deployment = ConfigDetectionConfiguration.parse_obj(detection_configuration.dict() | deployment.dict(exclude_unset=True))
 
             self.security_content_obj.deployment = deployment
 

--- a/contentctl/input/detection_builder.py
+++ b/contentctl/input/detection_builder.py
@@ -27,7 +27,11 @@ class DetectionBuilder():
 
     def addDeployment(self, detection_configuration: ConfigDetectionConfiguration) -> None:
         if self.security_content_obj:
-            self.security_content_obj.deployment = detection_configuration
+            deployment: ConfigDetectionConfiguration = self.security_content_obj.deployment
+            if not deployment:
+                deployment = detection_configuration
+            else:
+                deployment = detection_configuration.dict() | deployment.dict(exclude_unset=True)
 
 
     def addRBA(self) -> None:

--- a/contentctl/input/new_content_generator.py
+++ b/contentctl/input/new_content_generator.py
@@ -3,6 +3,7 @@ import uuid
 import questionary
 from dataclasses import dataclass
 from datetime import datetime
+from contentctl.objects.config import Config
 
 from contentctl.objects.enums import SecurityContentType
 from contentctl.input.new_content_questions import NewContentQuestions
@@ -11,7 +12,8 @@ from contentctl.input.new_content_questions import NewContentQuestions
 @dataclass(frozen=True)
 class NewContentGeneratorInputDto:
     type: SecurityContentType
-    
+    config: Config
+
 
 @dataclass(frozen=True)
 class NewContentGeneratorOutputDto:
@@ -60,8 +62,9 @@ class NewContentGenerator():
             self.output_dto.obj['tags']['required_fields'] = ['UPDATE']
             self.output_dto.obj['tags']['risk_score'] = 'UPDATE (impact * confidence)/100'
             self.output_dto.obj['tags']['security_domain'] = answers['security_domain']
-            #self.output_dto.obj['source'] = answers['detection_kind']
-        
+
+            if input_dto.config.custom_deployment:
+                self.output_dto.obj['deployment'] = input_dto.config.detection_configuration.dict(exclude_unset=True)
 
         elif input_dto.type == SecurityContentType.stories:
             questions = NewContentQuestions.get_questions_story()

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -155,6 +155,4 @@ class Config(BaseModel, extra=Extra.forbid):
     build: ConfigBuild = ConfigBuild()
     enrichments: ConfigEnrichments = ConfigEnrichments()
     test: Union[TestConfig,None] = None 
-    
-
-
+    custom_deployment: bool = False

--- a/poetry.lock
+++ b/poetry.lock
@@ -175,6 +175,20 @@ websocket-client = ">=0.32.0"
 ssh = ["paramiko (>=2.4.3)"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.1.3"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
+    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "future"
 version = "0.18.3"
 description = "Clean single-source support for Python 3 and 2"
@@ -221,6 +235,17 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
     {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
 
 [[package]]
@@ -311,6 +336,21 @@ files = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.2.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
+    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.39"
 description = "Library for building powerful interactive command lines in Python"
@@ -389,6 +429,28 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+
+[[package]]
+name = "pytest"
+version = "7.4.0"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.0-py3-none-any.whl", hash = "sha256:78bf16451a2eb8c7a2ea98e32dc119fd2aa758f1d5d66dbf0a59d69a3969df32"},
+    {file = "pytest-7.4.0.tar.gz", hash = "sha256:b4bf8c45bd59934ed84001ad51e11b4ee40d40a1229d2c79f9c592b0a3f6bd8a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytz"
@@ -728,6 +790,17 @@ docs = ["sphinx", "sphinx-prompt"]
 test = ["coverage", "pytest", "pytest-cov", "responses", "tox"]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.65.0"
 description = "Fast, Extensible Progress Meter"
@@ -832,4 +905,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1a552c0b23de4a3391a2b8d6b190492e1e1a75a92647d0f7772735c98d8ca6e0"
+content-hash = "0c66029d8f696b56e7cb30431764c8209541455af81b05acacce91bee618c930"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ tqdm = "^4.65.0"
 splunk-packaging-toolkit = "^1.0.1"
 
 [tool.poetry.dev-dependencies]
+pytest = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_detection_deployment.py
+++ b/tests/test_detection_deployment.py
@@ -1,6 +1,6 @@
 
 from contentctl.input.detection_builder import DetectionBuilder
-from contentctl.objects.config import ConfigDetectionConfiguration
+from contentctl.objects.config import ConfigDetectionConfiguration, ConfigNotable
 from contentctl.objects.detection import Detection
 from contentctl.objects.detection_tags import DetectionTags
 from contentctl.objects.enums import AnalyticsType
@@ -29,13 +29,58 @@ def test_add_deployment():
             required_fields=[],
             security_domain='access',
         ),
-        deployment=ConfigDetectionConfiguration(),
+        deployment=ConfigDetectionConfiguration.parse_obj({
+            'notable': {
+                'rule_title': 'specific title',
+                'rule_description': 'desc',
+                'nes_fields': []
+            }
+        }),
     )
-    detection.deployment.notable.rule_title = 'specific title'
-    default_config = ConfigDetectionConfiguration()
-    default_config.notable.rule_title = 'default title'
+    default_config = ConfigDetectionConfiguration.parse_obj({
+        'notable': {
+            'rule_title': 'default title',
+            'rule_description': 'desc',
+            'nes_fields': [],
+        }
+    })
     builder = DetectionBuilder()
     builder.security_content_obj = detection
     builder.addDeployment(default_config)
 
     assert detection.deployment.notable.rule_title == 'specific title'
+
+def test_add_nes_fields():
+    detection = Detection(
+        name="test detection",
+        type=AnalyticsType.correlation.name,
+        status="experimental",
+        data_source=[],
+        search="",
+        how_to_implement="",
+        known_false_positives="",
+        references=[],
+        tags=DetectionTags(
+            name="test detection",
+            observable=[],
+            analytic_story=[],
+            asset_type='foo',
+            confidence=1,
+            impact=1,
+            risk_score=0.01,
+            message='',
+            product=[],
+            required_fields=[],
+            security_domain='access',
+        ),
+        deployment=ConfigDetectionConfiguration(
+            notable=ConfigNotable(rule_title='foo', rule_description='bar', nes_fields=['foo', 'bar'])
+        ),
+    )
+    default_config = ConfigDetectionConfiguration()
+    builder = DetectionBuilder()
+    builder.security_content_obj = detection
+    builder.addDeployment(default_config)
+    builder.addNesFields()
+
+    assert detection.nes_fields == 'foo,bar'

--- a/tests/test_detection_deployment.py
+++ b/tests/test_detection_deployment.py
@@ -1,0 +1,41 @@
+
+from contentctl.input.detection_builder import DetectionBuilder
+from contentctl.objects.config import ConfigDetectionConfiguration
+from contentctl.objects.detection import Detection
+from contentctl.objects.detection_tags import DetectionTags
+from contentctl.objects.enums import AnalyticsType
+
+
+def test_add_deployment():
+    detection = Detection(
+        name="test detection",
+        type=AnalyticsType.correlation.name,
+        status="experimental",
+        data_source=[],
+        search="",
+        how_to_implement="",
+        known_false_positives="",
+        references=[],
+        tags=DetectionTags(
+            name="test detection",
+            observable=[],
+            analytic_story=[],
+            asset_type='foo',
+            confidence=1,
+            impact=1,
+            risk_score=0.01,
+            message='',
+            product=[],
+            required_fields=[],
+            security_domain='access',
+        ),
+        deployment=ConfigDetectionConfiguration(),
+    )
+    detection.deployment.notable.rule_title = 'specific title'
+    default_config = ConfigDetectionConfiguration()
+    default_config.notable.rule_title = 'default title'
+    builder = DetectionBuilder()
+    builder.security_content_obj = detection
+    builder.addDeployment(default_config)
+
+    assert detection.deployment.notable.rule_title == 'specific title'


### PR DESCRIPTION
This allows a detection to define response actions such as
notable, email, etc to override the global defaults.

This also adds a config option to copy the default config in to the
detection yaml on generation, to allow easier editing afterwards