### PR TITLE
Support configuring detection throttling

### DIFF
--- a/contentctl/input/detection_builder.py
+++ b/contentctl/input/detection_builder.py
@@ -83,6 +83,9 @@ class DetectionBuilder():
             if '`wineventlog_security`' in self.security_content_obj.search or '`powershell`' in self.security_content_obj.search:
                 self.security_content_obj.providing_technologies = ["Microsoft Windows"]
 
+    def addThrottleFields(self) -> None:
+        if self.security_content_obj and self.security_content_obj.throttling:
+            self.security_content_obj.throttling.fields = ",".join(list(self.security_content_obj.throttling.fields))
     
     def addNesFields(self) -> None:
         if self.security_content_obj:

--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -194,6 +194,7 @@ class Director():
         builder.addRBA()
         builder.addProvidingTechnologies()
         builder.addNesFields()
+        builder.addThrottleFields()
         builder.addAnnotations()
         builder.addMappings()
         builder.addBaseline(self.output_dto.baselines)

--- a/contentctl/input/new_content_generator.py
+++ b/contentctl/input/new_content_generator.py
@@ -3,6 +3,7 @@ import uuid
 import questionary
 from dataclasses import dataclass
 from datetime import datetime
+from contentctl.objects.detection_suppression import DetectionSuppression
 
 from contentctl.objects.enums import SecurityContentType
 from contentctl.input.new_content_questions import NewContentQuestions
@@ -43,6 +44,7 @@ class NewContentGenerator():
             self.output_dto.obj['how_to_implement'] = 'UPDATE_HOW_TO_IMPLEMENT'
             self.output_dto.obj['known_false_positives'] = 'UPDATE_KNOWN_FALSE_POSITIVES'            
             self.output_dto.obj['references'] = ['REFERENCE']
+            self.output_dto.obj['throttling'] = DetectionSuppression().dict()
             self.output_dto.obj['tags'] = dict()
             self.output_dto.obj['tags']['analytic_story'] = ['UPDATE_STORY_NAME']
             self.output_dto.obj['tags']['asset_type'] = 'UPDATE asset_type'

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, validator, root_validator, Extra
 from dataclasses import dataclass
 from typing import Union
 from datetime import datetime, timedelta
+from contentctl.objects.detection_suppression import DetectionSuppression
 
 
 from contentctl.objects.security_content_object import SecurityContentObject
@@ -36,6 +37,7 @@ class Detection_Abstract(SecurityContentObject):
     check_references: bool = False  
     references: list
     tags: DetectionTags
+    throttling: DetectionSuppression = DetectionSuppression()
     tests: list[UnitTest] = []
 
     # enrichments

--- a/contentctl/objects/detection_suppression.py
+++ b/contentctl/objects/detection_suppression.py
@@ -1,0 +1,10 @@
+import re
+
+from pydantic import BaseModel, validator, ValidationError, root_validator
+from contentctl.objects.mitre_attack_enrichment import MitreAttackEnrichment
+from contentctl.objects.constants import *
+
+class DetectionSuppression(BaseModel):
+    enabled: bool = False
+    fields: list[str] = []
+    window: str = '86400s'

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -105,6 +105,11 @@ relation = greater than
 quantity = 0
 realtime_schedule = 0
 is_visible = false
+{% if detection.throttling.enabled %}
+alert.suppress = true
+alert.suppress.fields = {{ detection.throttling.fields }}
+alert.suppress.period = {{ detection.throttling.window }}
+{% endif %}
 search = {{ detection.search }}
 
 {% endif %}


### PR DESCRIPTION
This adds the ability to configure detection throttling in the detection configuration itself. This allows full configuration of the detection prior to deployment, allowing users to define more behaviors of the detection in the repo itself