### PR TITLE
Add support for notable drilldown searches

### DIFF
--- a/contentctl/input/new_content_generator.py
+++ b/contentctl/input/new_content_generator.py
@@ -3,6 +3,7 @@ import uuid
 import questionary
 from dataclasses import dataclass
 from datetime import datetime
+from contentctl.objects.config import ConfigDrilldown
 
 from contentctl.objects.enums import SecurityContentType
 from contentctl.input.new_content_questions import NewContentQuestions
@@ -61,7 +62,11 @@ class NewContentGenerator():
             self.output_dto.obj['tags']['risk_score'] = 'UPDATE (impact * confidence)/100'
             self.output_dto.obj['tags']['security_domain'] = answers['security_domain']
             #self.output_dto.obj['source'] = answers['detection_kind']
-        
+            if answers['use_drilldown']:
+                self.output_dto.obj['drilldown'] = ConfigDrilldown(
+                    name=answers['drilldown_name'],
+                    search=answers['drilldown_search'],
+                ).dict()
 
         elif input_dto.type == SecurityContentType.stories:
             questions = NewContentQuestions.get_questions_story()

--- a/contentctl/input/new_content_questions.py
+++ b/contentctl/input/new_content_questions.py
@@ -56,6 +56,25 @@ class NewContentQuestions():
                 'default': '| UPDATE_SPL'
             },
             {
+                'type': 'confirm',
+                'message': 'Do you want to add a drilldown search?',
+                'name': 'use_drilldown',
+                'default': False,
+            },
+            {
+                'type': 'text',
+                'message': 'enter drilldown name',
+                'name': 'drilldown_name',
+                'when': lambda answers: answers['use_drilldown'],
+                'default': 'View Contributing Events',
+            },
+            {
+                'type': 'text',
+                'message': 'enter drilldown search (spl) (supports variables)',
+                'name': 'drilldown_search',
+                'when': lambda answers: answers['use_drilldown'],
+            },
+            {
                 'type': 'text',
                 'message': 'enter MITRE ATT&CK Technique IDs related to the detection, comma delimited for multiple',
                 'name': 'mitre_attack_ids',

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -15,7 +15,7 @@ from contentctl.objects.enums import AnalyticsType
 from contentctl.objects.enums import DataModel
 from contentctl.objects.enums import DetectionStatus
 from contentctl.objects.detection_tags import DetectionTags
-from contentctl.objects.config import ConfigDetectionConfiguration
+from contentctl.objects.config import ConfigDetectionConfiguration, ConfigDrilldown
 from contentctl.objects.unit_test import UnitTest
 from contentctl.objects.macro import Macro
 from contentctl.objects.lookup import Lookup
@@ -57,6 +57,7 @@ class Detection_Abstract(SecurityContentObject):
     nes_fields: str = None
     providing_technologies: list = None
     runtime: str = None
+    drilldown: ConfigDrilldown = None
 
     class Config:
         use_enum_values = True

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -20,6 +20,13 @@ class ConfigScheduling(BaseModel):
     schedule_window: str
 
 
+class ConfigDrilldown(BaseModel):
+    name: str
+    search: str
+    earliest_offset: str = "$info_min_time$"
+    latest_offset: str = "$info_max_time$"
+
+
 class ConfigNotable(BaseModel):
     rule_description: str
     rule_title: str

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -71,6 +71,12 @@ action.notable.param.rule_description = {{ detection.deployment.notable.rule_des
 action.notable.param.rule_title = {{ detection.deployment.notable.rule_title | custom_jinja2_enrichment_filter(detection) }}
 action.notable.param.security_domain = {{ detection.tags.security_domain }}
 action.notable.param.severity = high
+{% if detection.drilldown.name is defined %}
+action.notable.param.drilldown_name = {{ detection.drilldown.name }}
+action.notable.param.drilldown_search = {{ detection.drilldown.search }}
+action.notable.param.drilldown_earliest_offset = {{ detection.drilldown.earliest_offset }}
+action.notable.param.drilldown_latest_offset = {{ detection.drilldown.latest_offset }}
+{% endif %}
 {% endif %}
 {% if detection.deployment.email.to is defined %}
 action.email.subject.alert = {{ detection.deployment.email.subject | custom_jinja2_enrichment_filter(detection) }}


### PR DESCRIPTION
This adds the ability to configure a drilldown search for a detection
that will appear in the notable. This adds a question to the
new detection wizard for it as well.