### PR TITLE
Support SSA Status Validation and convert fixes

### DIFF
--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -554,6 +554,6 @@ def main():
         print(f"Error during contentctl:\n{str(e)}")
         import traceback
         traceback.print_exc()
-        traceback.print_stack()
+        #traceback.print_stack()
         sys.exit(1)
     

--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -107,7 +107,7 @@ class Director():
         else:
             files = Utils.get_all_yml_files_from_directory(os.path.join(self.input_dto.input_path, str(type.name)))
 
-        validation_error_found = False
+        validation_errors = []
                 
         already_ran = False
         progress_percent = 0
@@ -177,16 +177,15 @@ class Director():
                         already_ran = True
                         print(f"\r{f'{type_string} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...", end="", flush=True)
             
-            except ValidationError as e:
-                print(f"\nValidation Error for file '{file}'")
-                print(e)
-                validation_error_found = True
+            except (ValidationError, ValueError) as e:
+                validation_errors.append(e)
 
         print(f"\r{f'{type.name.upper()} Progress'.rjust(23)}: [{progress_percent:3.0f}%]...", end="", flush=True)
         print("Done!")
 
-        if validation_error_found:
-            sys.exit(1)
+        if len(validation_errors) > 0:
+            errors_string = '\n\n - '.join([str(e) for e in validation_errors])
+            raise Exception(f"The following {len(validation_errors)} error(s) were found during validation:\n\n - {errors_string}\n\nVALIDATION FAILED")
 
 
     def constructDetection(self, builder: DetectionBuilder, file_path: str) -> None:

--- a/contentctl/input/sigma_converter.py
+++ b/contentctl/input/sigma_converter.py
@@ -204,18 +204,16 @@ class SigmaConverter():
                 self.output_dto.detections.append(detection)
 
             except Exception as e:
-                print(e)
-                errors.append("ERROR: Converting detection " + detection.name)
+                errors.append(f"ERROR: Converting detection file '{detection_file}': {str(e)}")
 
-        print()
-        for error in errors:
-            print(error)
-        
-        print()
+        if len(errors) > 0:
+            errors_string = '\n\t'.join(errors)
+            raise Exception(f"The following errors were encountered during conversion:\n\t{errors_string}")
 
     def read_detection(self, detection_path : str) -> Detection:
         yml_dict = YmlReader.load_file(detection_path)
         yml_dict["tags"]["name"] = yml_dict["name"]
+        
         detection = Detection.parse_obj(yml_dict)
         detection.source = os.path.split(os.path.dirname(detection_path))[-1]  
         return detection 

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -111,7 +111,7 @@ class Detection_Abstract(SecurityContentObject):
             else:
                 raise ValueError(f"The following is NOT an ssa_ detection, but has 'status: {v}' which may ONLY be used for ssa_ detections: {values['file_path']}")
         
-        return values
+        return v
 
     # @root_validator
     # def search_validation(cls, values):

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -86,6 +86,17 @@ class Detection_Abstract(SecurityContentObject):
 
     @validator('how_to_implement', 'search', 'known_false_positives')
     def encode_error(cls, v, values, field):
+        if not isinstance(v,str):
+            if isinstance(v,dict) and field.name == "search":
+                #This is a special case of the search field.  It can be a dict, containing
+                #a sigma search, if we are running the converter. So we will not
+                #validate the field further. Additional validation will be done
+                #during conversion phase later on
+                return v
+            else:
+                #No other fields should contain a non-str type:
+                raise ValueError(f"Error validating field '{field.name}'. Field MUST be be a string, not type '{type(v)}' ")
+
         return SecurityContentObject.free_text_field_valid(cls,v,values,field)
 
     @root_validator

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -165,7 +165,7 @@ class Detection_Abstract(SecurityContentObject):
     def tests_validate(cls, v, values):
         if values.get("status","") == DetectionStatus.production.value and not v:
             raise ValueError(
-                "One or more tests is REQUIRED for production detection: " + values["name"]
+                "At least one test is REQUIRED for production detection: " + values["name"]
             )
         return v
     

--- a/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
@@ -45,11 +45,12 @@ class SecurityContentObject_Abstract(BaseModel, abc.ABC):
 
     @staticmethod
     def free_text_field_valid(input_cls, v, values, field):
-        
         try:
             v.encode('ascii')
         except UnicodeEncodeError as e:
             print(f"Potential Ascii encoding error in {values['name']}:{field.name} - {str(e)}")
+        except Exception as e:
+            print(f"Unknown encoding error in {values['name']}:{field.name} - {str(e)}")
         
         
         if bool(re.search(r"[^\\]\n", v)):

--- a/contentctl/objects/ssa_detection.py
+++ b/contentctl/objects/ssa_detection.py
@@ -31,7 +31,7 @@ class SSADetection(BaseModel):
     date: str
     author: str
     type: str
-    status: DetectionStatus
+    status: DetectionStatus = ...
     description: str
     data_source: list[str]
     search: Union[str, dict]
@@ -136,12 +136,6 @@ class SSADetection(BaseModel):
     # def references_check(cls, v, values):
     #     return LinkValidator.SecurityContentObject_validate_references(v, values)
 
-    @root_validator
-    def missing_test_file(cls, values):
-        if values["status"] == DetectionStatus.production:
-            if "tests" not in values:
-                raise ValueError("Missing test file for detection: " + values["name"])
-        return values
 
     @validator("search")
     def search_validate(cls, v, values):
@@ -150,8 +144,8 @@ class SSADetection(BaseModel):
 
     @validator("tests")
     def tests_validate(cls, v, values):
-        if values["status"] != DetectionStatus.production and not v:
+        if (values.get("status","") in [DetectionStatus.production.value, DetectionStatus.validation.value]) and not v:
             raise ValueError(
-                "tests value is needed for production detection: " + values["name"]
+                "At least one test is required for a production or validation detection: " + values["name"]
             )
         return v


### PR DESCRIPTION
There were a number of features that prevented contentctl convert from working directly around the introduction
of status: validation for ssa content.
That has been fixed.
A number of other validation and error-printing enhancement have also been added.