### PR TITLE
Adding newline after all arguments, not after evry single argument

### DIFF
--- a/contentctl/output/templates/macros.j2
+++ b/contentctl/output/templates/macros.j2
@@ -2,8 +2,8 @@
 {% for macro in objects %}
 [{{ macro.name }}{% if macro.arguments is not none %}({{ macro.arguments|length }}){% endif %}]
 {% if macro.arguments is not none %}
-args = {% for arg in macro.arguments %}{{ arg }}{{ ", " if not loop.last }}
-{% endfor %}
+args = {% for arg in macro.arguments %}{{ arg }}{{ ", " if not loop.last }}{% endfor %}
+
 {% endif %}
 {% if macro.definition is not none %}
 definition = {{ macro.definition }}


### PR DESCRIPTION
Noticed that if you added more arguments to a macro, splunk would complain about the arguments being spread over several lines. Suggesting fix by having the arguments on the same line, with a newline after all the arguments.


Was told to make a PR here: https://github.com/splunk/security_content/pull/2908