### PR TITLE
removing file_path_key from SSE API files

### DIFF
--- a/contentctl/output/api_json_output.py
+++ b/contentctl/output/api_json_output.py
@@ -30,6 +30,7 @@ class ApiJsonOutput():
                         "data_source": True,
                         "tests": True,
                         "cve_enrichment": True,
+                        "file_path": True,
                         "tags": 
                             {
                                 "file_path": True,
@@ -41,7 +42,13 @@ class ApiJsonOutput():
                             }
                     }
                 ))
-            
+
+            for detection in obj_array:
+                # Loop through each macro in the detection
+                for macro in detection["macros"]:
+                    # Remove the 'file_path' key if it exists
+                    macro.pop("file_path", None)
+
             JsonWriter.writeJsonObject(os.path.join(output_path, 'detections.json'), {'detections': obj_array })
 
             ### Code to be added to contentctl to ship filter macros to macros.json
@@ -65,6 +72,10 @@ class ApiJsonOutput():
             for item in uniques:
                 obj_array.append(json.loads(item))
 
+            for obj in obj_array:
+                if 'file_path' in obj:
+                   del obj['file_path']
+
             JsonWriter.writeJsonObject(os.path.join(output_path, 'macros.json'), {'macros': obj_array})
 
         
@@ -75,7 +86,8 @@ class ApiJsonOutput():
                 obj_array.append(story.dict(exclude_none=True,
                     exclude =
                     {
-                        "investigations": True
+                        "investigations": True,
+                        "file_path": True
                     }
                 ))
 
@@ -100,7 +112,12 @@ class ApiJsonOutput():
             obj_array = []
             for investigation in objects:
                 investigation.id = str(investigation.id)
-                obj_array.append(investigation.dict(exclude_none=True))
+                obj_array.append(investigation.dict(
+                    exclude =
+                    {
+                        "file_path":True,
+                    }
+                ))
 
             JsonWriter.writeJsonObject(os.path.join(output_path, 'response_tasks.json'), {'response_tasks': obj_array })
         
@@ -108,7 +125,12 @@ class ApiJsonOutput():
             obj_array = []
             for lookup in objects:
 
-                obj_array.append(lookup.dict(exclude_none=True))
+                obj_array.append(lookup.dict(
+                    exclude =
+                    {
+                        "file_path":True,
+                    }
+                ))
 
 
             JsonWriter.writeJsonObject(os.path.join(output_path, 'lookups.json'), {'lookups': obj_array })


### PR DESCRIPTION
This PR removes the "file_path" key from the all jsons that are generated for SSE