### PR TITLE
adding experimental warning

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -6,9 +6,9 @@
 action.escu = 0
 action.escu.enabled = 1
 {% if detection.status == "deprecated" %}
-description = **WARNING**, this detection has been marked **DEPRECATED** by the Splunk Threat Research team, this means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }}
+description = **WARNING**, this detection has been marked **DEPRECATED** by the Splunk Threat Research Team. This means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }}
 {% elif detection.status == "experimental" %}
-description = **WARNING**, this detection is marked **EXPERIMENTAL** by the Splunk Threat Research team, this means that the detected has been manually tested and we do not have the associated attack data to do automated testing or share this attack dataset due to it sensitive nature. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
+description = **WARNING**, this detection is marked **EXPERIMENTAL** by the Splunk Threat Research Team. This means that the detected has been manually tested and we do not have the associated attack data to perform automated testing or cannot share this attack dataset due to its sensitive nature. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
 {% else %}
 description = {{ detection.description }}
 {% endif %}

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -6,7 +6,9 @@
 action.escu = 0
 action.escu.enabled = 1
 {% if detection.status == "deprecated" %}
-description = WARNING, this detection has been marked deprecated by the Splunk Threat Research team, this means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
+description = **WARNING**, this detection has been marked **DEPRECATED** by the Splunk Threat Research team, this means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }}
+{% elif detection.status == "experimental" %}
+description = **WARNING**, this detection is marked **EXPERIMENTAL** by the Splunk Threat Research team, this means that the detected has been manually tested and we do not have the associated attack data to do automated testing or share this attack dataset due to it sensitive nature. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
 {% else %}
 description = {{ detection.description }}
 {% endif %}
@@ -27,7 +29,6 @@ action.escu.creation_date = {{ detection.date }}
 action.escu.modification_date = {{ detection.date }}
 action.escu.confidence = high
 action.escu.full_search_name = {{APP_NAME}} - {{ detection.name }} - Rule
-action.escu.search_type = detection
 {% if detection.tags.product is defined %}
 action.escu.product = {{ detection.tags.product | tojson }}
 {% endif %}
@@ -54,6 +55,8 @@ dispatch.latest_time = {{ detection.deployment.scheduling.latest_time }}
 action.correlationsearch.enabled = 1
 {% if detection.status == "deprecated" %}
 action.correlationsearch.label = {{APP_NAME}} - Deprecated - {{ detection.name }} - Rule
+{% elif detection.status == "experimental" %}
+action.correlationsearch.label = {{APP_NAME}} - Experimental - {{ detection.name }} - Rule
 {% elif detection.type | lower == "correlation" %}
 action.correlationsearch.label = {{APP_NAME}} - RIR - {{ detection.name }} - Rule
 {% else %}

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -29,6 +29,7 @@ action.escu.creation_date = {{ detection.date }}
 action.escu.modification_date = {{ detection.date }}
 action.escu.confidence = high
 action.escu.full_search_name = {{APP_NAME}} - {{ detection.name }} - Rule
+action.escu.search_type = detection
 {% if detection.tags.product is defined %}
 action.escu.product = {{ detection.tags.product | tojson }}
 {% endif %}

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -8,7 +8,7 @@ action.escu.enabled = 1
 {% if detection.status == "deprecated" %}
 description = **WARNING**, this detection has been marked **DEPRECATED** by the Splunk Threat Research Team. This means that it will no longer be maintained or supported. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }}
 {% elif detection.status == "experimental" %}
-description = **WARNING**, this detection is marked **EXPERIMENTAL** by the Splunk Threat Research Team. This means that the detected has been manually tested and we do not have the associated attack data to perform automated testing or cannot share this attack dataset due to its sensitive nature. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
+description = **WARNING**, this detection is marked **EXPERIMENTAL** by the Splunk Threat Research Team. This means that the detection has been manually tested but we do not have the associated attack data to perform automated testing or cannot share this attack dataset due to its sensitive nature. If you have any questions feel free to email us at: research@splunk.com. {{ detection.description }} 
 {% else %}
 description = {{ detection.description }}
 {% endif %}


### PR DESCRIPTION
This PR updates the description for Experimental searches and also updates the full search name so that it gets reflected in Content Management

All 157 detections accurately updated

Testing:
<img width="1719" alt="image" src="https://github.com/splunk/contentctl/assets/7771446/b8f4d767-f177-4776-ba40-54bca0695ba8">

<img width="1715" alt="image" src="https://github.com/splunk/contentctl/assets/7771446/a9735775-9bc5-4017-95b3-34737ffc48b1">

