### PR TITLE
Add import command

### DIFF
--- a/contentctl/actions/conf_import.py
+++ b/contentctl/actions/conf_import.py
@@ -33,6 +33,8 @@ class Import:
                     yml_detection = YmlReader.load_file(yml_path[0])
                     print(f"[*] Updating {yml_path[0].name}")
                     yml_detection['search'] = conf_detection['search']
+                    if 'file_path' in yml_detection:
+                        del yml_detection['file_path']
                     YmlWriter.writeYmlFile(yml_path[0], yml_detection)
                     count += 1
                     

--- a/contentctl/actions/conf_import.py
+++ b/contentctl/actions/conf_import.py
@@ -1,0 +1,43 @@
+import pathlib
+from dataclasses import dataclass
+from yaml import load, dump
+try:
+    from yaml import CLoader as Loader, CDumper as Dumper
+except ImportError:
+    from yaml import Loader, Dumper
+
+from contentctl.input.conf_reader import ConfReader
+from contentctl.output.yml_output import YmlOutput
+from contentctl.input.director import (
+    Director,
+    DirectorInputDto,
+    DirectorOutputDto,
+)
+from contentctl.input.detection_builder import DetectionBuilder
+from contentctl.objects.enums import SecurityContentType
+
+
+@dataclass(frozen=True)
+class ImportInputDto:
+    input_path: pathlib.Path
+    director_input_dto: DirectorInputDto
+
+
+class Import:
+
+    def execute(self, input_dto: ImportInputDto) -> None:
+        conf_obj = ConfReader.load_file(input_dto.input_path)
+        director_output_dto = DirectorOutputDto([],[],[],[],[],[],[],[],[])
+        director = Director(director_output_dto)
+        director.execute(input_dto.director_input_dto)
+        for savedsearch in conf_obj:
+            for i in range(len(director.output_dto.detections)):
+                if director.output_dto.detections[i].name == savedsearch['name']:
+                    if 'search' in savedsearch:
+                        with open(director.output_dto.detections[i].file_path, 'r') as f:
+                            yml_rule = load(f.read(),Loader=Loader)
+                        yml_rule['search'] = savedsearch['search']
+                        with open(director.output_dto.detections[i].file_path, 'w') as f:
+                            f.write(dump(yml_rule, sort_keys=False,))
+
+        return None

--- a/contentctl/actions/conf_import.py
+++ b/contentctl/actions/conf_import.py
@@ -1,4 +1,4 @@
-import os
+import sys
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,27 +17,61 @@ class ImportInputDto:
 class Import:
 
     def execute(self, input_dto: ImportInputDto) -> None:
-        detections_path = os.path.join(input_dto.input_path, 'detections')
-        conf_obj = ConfReader.load_file(input_dto.conf_path)
+        savedsearches = None
+        macros = None
+        lookups = None
 
-        print(f"Loaded {len(conf_obj)} saved searches\n")
+        if input_dto.conf_path.is_dir():
+            conf_files = list(input_dto.conf_path.glob('*.conf'))
+            if len(conf_files) > 0:
+                for conf_file in conf_files:
+                    if conf_file.name == 'savedsearches.conf':
+                        savedsearches = True
+                        savedsearches_path = conf_file
+                    elif conf_file.name == 'macros.conf':
+                        macros = True
+                        macros_file = conf_file
+                    elif conf_file.name == 'lookups.conf':
+                        lookups = True
+                        lookups_file = conf_file
+        elif input_dto.conf_path.name == 'savedsearches.conf' and input_dto.conf_path.exists():
+            savedsearches = True
+            savedsearches_path = input_dto.conf_path
+        elif input_dto.conf_path.name == 'macros.conf' and input_dto.conf_path.exists():
+            macros = True
+            macros_path = input_dto.conf_path
+        elif input_dto.conf_path.name == 'macros.conf' and input_dto.conf_path.exists():
+            lookups = True
+            lookups_path = input_dto.conf_path
+        else:
+            print('[!] No config files found, check path or permissions')
+            sys.exit(1)
 
-        count = 0
-        for conf_detection in conf_obj:
-            conf_detection['file_name'] = conf_detection['name'].lower().replace(' ', '_')+'.yml'
+        if savedsearches:
+            detections_path = input_dto.input_path.joinpath('detections')
+            conf_obj = ConfReader.load_file(savedsearches_path)
+            print(f"Loaded {len(conf_obj)} saved searches\n")
+            count = 0
+            for conf_detection in conf_obj:
+                conf_detection['file_name'] = conf_detection['name'].lower().replace(' ', '_')+'.yml'
+                if 'search' in conf_detection:
+                    yml_path = list(Path(detections_path).rglob(conf_detection['file_name']))
+                    if len(yml_path) > 0:
+                        yml_detection = YmlReader.load_file(yml_path[0])
+                        print(f"[*] Updating {yml_path[0].name}")
+                        yml_detection['search'] = conf_detection['search']
+                        if 'file_path' in yml_detection:
+                            del yml_detection['file_path']
+                        YmlWriter.writeYmlFile(yml_path[0], yml_detection)
+                        count += 1
+            print(f'\nUpdated {count} detections\n')
 
-            if 'search' in conf_detection:
-                yml_path = list(Path(detections_path).rglob(conf_detection['file_name']))
+        if macros:
+            print('[!] macros.conf import not currently implemented')
+            # macros_path = input_dto.input_path.joinpath('macros')
 
-                if len(yml_path) > 0:
-                    yml_detection = YmlReader.load_file(yml_path[0])
-                    print(f"[*] Updating {yml_path[0].name}")
-                    yml_detection['search'] = conf_detection['search']
-                    if 'file_path' in yml_detection:
-                        del yml_detection['file_path']
-                    YmlWriter.writeYmlFile(yml_path[0], yml_detection)
-                    count += 1
-                    
-        print(f'\nUpdated {count} detections')
+        if lookups:
+            print('[!] lookups.conf import not currently implemented')
+            # lookups_path = input_dto.input_path.joinpath('lookups')
 
         return None

--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -105,25 +105,11 @@ def initialize(args) -> None:
 
 
 def conf_import(args) -> None:
-    config = start(args)
-    # if args.type == "app":
-    product_type = SecurityContentProduct.SPLUNK_APP
-    # elif args.type == "ssa":
-    #     product_type = SecurityContentProduct.SSA
-    # elif args.type == "api":
-    #     product_type = SecurityContentProduct.API
-    # else:
-    #     print(f"Invalid build type. Valid options app, ssa or api")
-    #     sys.exit(1)
-    director_input_dto = DirectorInputDto(
-        input_path=pathlib.Path(args.path),
-        product=product_type, 
-        config=config
+    import_input_dto = ImportInputDto(
+        input_path=pathlib.Path(os.path.abspath(args.path)),
+        conf_path=pathlib.Path(os.path.abspath(args.config))
     )
-    Import().execute(ImportInputDto(
-        input_path=pathlib.Path(os.path.abspath(args.config)),
-        director_input_dto=director_input_dto
-    ))
+    Import().execute(import_input_dto)
 
 
 

--- a/contentctl/input/conf_reader.py
+++ b/contentctl/input/conf_reader.py
@@ -1,0 +1,36 @@
+import configparser
+import pathlib
+import re
+import sys
+
+from typing import List
+
+
+class ConfReader():
+
+    @staticmethod
+    def load_file(file_path: pathlib.Path) -> List:
+        try:
+            with open(file_path, 'r') as f:
+                conf = re.sub(r'^\|', '\t|', f.read(), flags=re.MULTILINE)
+            config = configparser.ConfigParser()
+            config.read_string(conf)
+            conf_obj = []
+            for section_name in config.sections():
+                obj = {'name': section_name.split(' - ')[1].strip()}
+                for key, value in config[section_name].items():
+                    if key in (
+                        'disabled',
+                        'action.send_notable_to_mc_alert_action',
+                        'action.add_events',
+                        'alert.suppress',
+                    ):
+                        obj[key] = bool(value)
+                    else:
+                        obj[key] = value
+                conf_obj.append(obj)
+        except OSError as exc:
+            print(exc)
+            sys.exit(1)
+
+        return conf_obj

--- a/contentctl/input/conf_reader.py
+++ b/contentctl/input/conf_reader.py
@@ -1,9 +1,10 @@
-import configparser
 import pathlib
 import re
 import sys
 
 from typing import List
+
+from addonfactory_splunk_conf_parser_lib import TABConfigParser
 
 
 class ConfReader():
@@ -12,10 +13,9 @@ class ConfReader():
     def load_file(file_path: pathlib.Path) -> List:
         try:
             with open(file_path, 'r') as f:
-                conf = re.sub(r'^\|', '\t|', f.read(), flags=re.MULTILINE)
-                conf = re.sub(r' \\$', ' ', conf, flags=re.MULTILINE)
-            config = configparser.ConfigParser()
-            config.read_string(conf)
+                conf_file = f.read()
+            config = TABConfigParser()
+            config.read_string(conf_file)
             conf_obj = []
             for section_name in config.sections():
                 obj = {'name': section_name.split(' - ')[1].strip()}

--- a/contentctl/input/conf_reader.py
+++ b/contentctl/input/conf_reader.py
@@ -13,6 +13,7 @@ class ConfReader():
         try:
             with open(file_path, 'r') as f:
                 conf = re.sub(r'^\|', '\t|', f.read(), flags=re.MULTILINE)
+                conf = re.sub(r' \\$', ' ', conf, flags=re.MULTILINE)
             config = configparser.ConfigParser()
             config.read_string(conf)
             conf_obj = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ tqdm = "^4.65.0"
 #splunk-appinspect = "^2.36.0"
 pysigma = "^0.10.5"
 pysigma-backend-splunk = "^1.0.3"
+addonfactory-splunk-conf-parser-lib = "^0.4.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
This PR adds support for importing updated searches from an existing savedsearches.conf.

```
contentctl -p <path_to_content> import -c <path_to_savedsearches.conf>
```

For the sake of simplicity I opted to read the detection rules, update the search string and write the updated yml back. Whilst it's not perfect, at the very least it's idempotent and only updates detections with updated searches.

I'd value any feedback or contributions (from Splunk and customers) for the next round of updates to this feature branch 🙂
