### PR TITLE
[TR-3481] Sourcetype output

### DIFF
--- a/contentctl/output/finding_report_writer.py
+++ b/contentctl/output/finding_report_writer.py
@@ -63,7 +63,7 @@ class FindingReportObject():
             evidence_str = evidence_str + '"' + detection.tags.observable[i]["name"] + '": ' + detection.tags.observable[i]["name"].replace(".", "_")
             if not i == (len(detection.tags.observable) - 1):
                 evidence_str = evidence_str + ', '
-        evidence_str = evidence_str + '}'        
+        evidence_str = evidence_str + '"sourceType": metadata.source_type}'        
 
         detection.tags.evidence_str = evidence_str
 

--- a/contentctl/output/finding_report_writer.py
+++ b/contentctl/output/finding_report_writer.py
@@ -63,7 +63,7 @@ class FindingReportObject():
             evidence_str = evidence_str + '"' + detection.tags.observable[i]["name"] + '": ' + detection.tags.observable[i]["name"].replace(".", "_")
             if not i == (len(detection.tags.observable) - 1):
                 evidence_str = evidence_str + ', '
-        evidence_str = evidence_str + '"sourceType": metadata.source_type}'        
+        evidence_str = evidence_str + '", sourceType": metadata.source_type}'        
 
         detection.tags.evidence_str = evidence_str
 


### PR DESCRIPTION
Adding the `sourceType` output in BA Finding Reports for TR-3481. This is good to go whenever.
#79  will be held until BA is ready for TR-3482.