### PR TITLE
Fix manual test bug

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructure.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructure.py
@@ -375,7 +375,20 @@ class DetectionTestingInfrastructure(BaseModel, abc.ABC):
                 self.sync_obj.currentTestingQueue[self.get_name()] = None
 
     def test_detection(self, detection: Detection):
-        if detection.tests is None:
+        if detection.tags.manual_test:
+            if len(detection.tests) != 1:
+                raise Exception(f"Detection {detection.name} configured for manual_test, but no "
+                                "manual_test was found in tests section. It should have been "
+                                f"added automatically: {detection.tests}")
+            elif detection.tests[0].name != "MANUAL_TEST_ONLY":
+                raise Exception(f"Detection {detection.name} configured for manual_test, but a test "
+                                f"{detection.tests[0]}was found INSTEAD of the automatically added "
+                                "MANUAL_TEST_ONLY")
+            else:
+                detection.tests[0].result = UnitTestResult()
+                detection.tests[0].result.set_manual_test(detection.tags.manual_test)
+                return
+        elif detection.tests is None:
             self.pbar.write(f"No test(s) found for {detection.name}")
             return
 

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -175,7 +175,7 @@ class Detection_Abstract(SecurityContentObject):
         tags_obj = values.get("tags")
         if tags_obj and tags_obj.manual_test:
             #If any tests are present while manual_test is set, replace them with the manual_test placeholder
-            return [{"name":"MANUAL_TEST_ONLY"}]
+            return [UnitTest(name="MANUAL_TEST_ONLY",attack_data=[])]
 
         if len(v) < 1:
             raise ValueError("At least one test is REQUIRED for production detection: " + values.get("name", "NO NAME FOUND"))

--- a/contentctl/objects/unit_test_result.py
+++ b/contentctl/objects/unit_test_result.py
@@ -54,6 +54,15 @@ class UnitTestResult(BaseModel):
 
         return results_dict
 
+    def set_manual_test(self,manual_test_text:str):
+        self.duration = 0
+        self.exception = None
+        self.message = f"manual_test: {manual_test_text}"
+        self.success = True
+        self.job_content = None
+        self.sid_link = "manual_test - NO Search ID"
+        return self.success
+    
     def set_job_content(
         self,
         content: Union[Record, None],


### PR DESCRIPTION
Respect manual_testing flag.
Previously, there was a bug where the validator was not always working as expected because:
1.  If tests were not defined, then the validator was not called. This has been fixed by setting it to always=True
2.  Because of the way tests are run and results are generated, it was showing as a failure. We now show a manual test as a "successful" test with a special message indicating that it was marked as "manual_test" in the output in test_results/summary.yml. Please see the attached image as an example. This should make it easy to review results.

Note that test 'name' and 'message' fields have been dynamically generated at run time due to the presence of the manual_test field:
<img width="1293" alt="image" src="https://github.com/splunk/contentctl/assets/87383215/799a1724-b6e9-4d76-80ca-9509c7fb7592">
 