### PR TITLE
Set up splunk container once and reuse it

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
@@ -109,9 +109,6 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
         return container
 
     def removeContainer(self, removeVolumes: bool = True, forceRemove: bool = True):
-        if self.global_config.infrastructure_config.persist_and_reuse_container:
-            print(f"\nContainer [{self.get_name()}] has NOT been terminated because 'contentctl_test.yml ---> infrastructure_config ---> persist_and_reuse_container = True'\n")
-            return
         try:
             container: docker.models.containers.Container = (
                 self.get_docker_client().containers.get(self.get_name())
@@ -120,7 +117,12 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
             # Container does not exist, no need to try and remove it
             return
         try:
-
+            # If the user wants to persist the container (or use a previously configured container), then DO NOT remove it.
+            # Emit the following message, which they will see on initial setup and teardown at the end of the test. 
+            if self.global_config.infrastructure_config.persist_and_reuse_container:
+                print(f"\nContainer [{self.get_name()}] has NOT been terminated because 'contentctl_test.yml ---> infrastructure_config ---> persist_and_reuse_container = True'")
+                print(f"To remove it, please manually run the following at the command line: `docker container rm -fv {self.get_name()}`\n")
+                return
             # container was found, so now we try to remove it
             # v also removes volumes linked to the container
             container.remove(v=removeVolumes, force=forceRemove)

--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -433,6 +433,13 @@ def main():
         help="path to the content path containing the contentctl.yml",
     )
 
+    parser.add_argument(
+        "--disable_enrichment",
+        required=False,
+        action="store_true",
+        help="Enrichment is only REQUIRED when building a release (or testing a release). In most cases, it is not required. Disabling enrichment will significantly speed up all contentctl commands."
+    )
+
     parser.set_defaults(func=lambda _: parser.print_help())
     actions_parser = parser.add_subparsers(
         title="Splunk content actions", dest="action"
@@ -640,6 +647,7 @@ def main():
         help="Whether integration testing should be enabled, in addition to unit testing (requires a configured Splunk "
         "instance with ES installed)"
     )
+
     # TODO (cmcginley): add flag for enabling logging for correlation_search logging
     # TODO (cmcginley): add flag for changing max_sleep time for integration tests
     # TODO (cmcginley): add setting to skip listing skips -> test_config.TestConfig,

--- a/contentctl/helper/config_handler.py
+++ b/contentctl/helper/config_handler.py
@@ -4,7 +4,7 @@ import sys
 import pathlib
 
 from contentctl.input.yml_reader import YmlReader
-from contentctl.objects.config import Config, TestConfig
+from contentctl.objects.config import Config, TestConfig, ConfigEnrichments
 from contentctl.objects.enums import DetectionTestingMode
 from typing import Union
 import argparse
@@ -23,6 +23,8 @@ class ConfigHandler:
 
         try: 
             config = Config.parse_obj(yml_dict)
+            if args.disable_enrichment:
+                config.enrichments = ConfigEnrichments(attack_enrichment=False,cve_enrichment=False,splunk_app_enrichment=False)
         except Exception as e:
             raise Exception(f"Error reading config file: {str(e)}")
             

--- a/contentctl/objects/test_config.py
+++ b/contentctl/objects/test_config.py
@@ -163,6 +163,9 @@ class InfrastructureConfig(BaseModel, extra=Extra.forbid, validate_assignment=Tr
         default=DetectionTestingTargetInfrastructure.container,
         title=f"Control where testing should be launched.  Choose one of {DetectionTestingTargetInfrastructure._member_names_}",
     )
+
+    persist_and_reuse_container:bool = True
+
     full_image_path: str = Field(
         default="registry.hub.docker.com/splunk/splunk:latest",
         title="Full path to the container image to be used",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "3.1.0"
+version = "3.2.0"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Experimental support for reusing a
configured splunk environment for
subsequent tests. This is a huge
time-savings for detection
engineers.