### PR TITLE
--disable_enrichment to --enable_enrichment

### DIFF
--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -445,10 +445,10 @@ def main():
     )
 
     parser.add_argument(
-        "--disable_enrichment",
+        "--enable_enrichment",
         required=False,
         action="store_true",
-        help="Enrichment is only REQUIRED when building a release (or testing a release). In most cases, it is not required. Disabling enrichment will significantly speed up all contentctl commands."
+        help="Enrichment is only REQUIRED when building a release (or testing a release). In most cases, it is not required. Disabling enrichment BY DEFAULT (which is the default setting in contentctl.yml) is a signifcant time savings."
     )
 
     parser.set_defaults(func=lambda _: parser.print_help())

--- a/contentctl/helper/config_handler.py
+++ b/contentctl/helper/config_handler.py
@@ -28,8 +28,11 @@ class ConfigHandler:
 
         try: 
             config = Config.parse_obj(yml_dict)
-            if args.disable_enrichment:
-                config.enrichments = ConfigEnrichments(attack_enrichment=False,cve_enrichment=False,splunk_app_enrichment=False)
+            if args.enable_enrichment:
+                config.enrichments = ConfigEnrichments(attack_enrichment=True,cve_enrichment=True,splunk_app_enrichment=False)
+            else:
+                # Use whatever setting is in contentctl.yml
+                pass
         except Exception as e:
             raise Exception(f"Error reading config file: {str(e)}")
             


### PR DESCRIPTION
Since disabled enrichment is the more common case, that will now be the default. As such, the command line flag
--disable_enrichment has been changed to --enable_enrichment, with the default setting being written to contentctl.yml being False for all enrichments.