### PR TITLE
ACS support 

### DIFF
--- a/contentctl/actions/acs_deploy.py
+++ b/contentctl/actions/acs_deploy.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from contentctl.input.director import DirectorInputDto
+from contentctl.output.conf_output import ConfOutput
+
+
+from typing import Union
+
+@dataclass(frozen=True)
+class ACSDeployInputDto:
+    director_input_dto: DirectorInputDto
+    splunk_api_username: str
+    splunk_api_password: str
+    splunk_cloud_jwt_token: str
+    splunk_cloud_stack: str
+    stack_type: str
+
+
+class Deploy:
+    def execute(self, input_dto: ACSDeployInputDto) -> None:
+        
+        conf_output = ConfOutput(input_dto.director_input_dto.input_path, input_dto.director_input_dto.config)
+        
+        appinspect_token = conf_output.inspectAppAPI(input_dto.splunk_api_username, input_dto.splunk_api_password, input_dto.stack_type)
+        
+
+        if input_dto.splunk_cloud_jwt_token is None or input_dto.splunk_cloud_stack is None:
+            if input_dto.splunk_cloud_jwt_token is None:
+                raise Exception("Cannot deploy app via ACS, --splunk_cloud_jwt_token was not defined on command line.")
+            else:
+                raise Exception("Cannot deploy app via ACS, --splunk_cloud_stack was not defined on command line.")
+        
+        conf_output.deploy_via_acs(input_dto.splunk_cloud_jwt_token,
+                                input_dto.splunk_cloud_stack, 
+                                appinspect_token,
+                                input_dto.stack_type)
+
+        
+        

--- a/contentctl/actions/generate.py
+++ b/contentctl/actions/generate.py
@@ -17,9 +17,11 @@ from typing import Union
 @dataclass(frozen=True)
 class GenerateInputDto:
     director_input_dto: DirectorInputDto
-    appinspect_api_username: Union[str,None] = None
-    appinspect_api_password: Union[str,None] = None
-
+    splunk_api_username: Union[str,None] = None
+    splunk_api_password: Union[str,None] = None
+    #For most cloud stacks, the stack_type argument has been deprecated for appinspect.
+    #Still, we will pass it in case there are users of very old stacks.
+    stack_type: str = "victoria"
 
 class Generate:
 
@@ -29,13 +31,15 @@ class Generate:
         director.execute(input_dto.director_input_dto)
 
         if input_dto.director_input_dto.product == SecurityContentProduct.SPLUNK_APP:
-            if input_dto.appinspect_api_username and input_dto.appinspect_api_password:
-                pass
-            elif input_dto.appinspect_api_username or input_dto.appinspect_api_password:
-                if input_dto.appinspect_api_password:
-                    raise Exception("appinspect_api_password was provided, but appinspect_api_username was not. Please provide both or neither")
+            if (input_dto.splunk_api_username is None) ^ (input_dto.splunk_api_password is None):
+                # Exclusive OR above finds when ONE of these is defined but the other is not
+                if input_dto.splunk_api_password:
+                    raise Exception("splunk_api_password was provided, but splunk_api_username was not. Please provide both or neither")
                 else:
-                    raise Exception("appinspect_api_username was provided, but appinspect_api_password was not. Please provide both or neither")            
+                    raise Exception("splunk_api_username was provided, but splunk_api_password was not. Please provide both or neither")                
+
+
+            
             
             conf_output = ConfOutput(input_dto.director_input_dto.input_path, input_dto.director_input_dto.config)
             conf_output.writeHeaders()
@@ -48,10 +52,10 @@ class Generate:
             conf_output.writeAppConf()
             conf_output.packageApp()
 
-            conf_output.inspectAppCLI()
-            if input_dto.appinspect_api_username and input_dto.appinspect_api_password:
-                conf_output.inspectAppAPI(input_dto.appinspect_api_username, input_dto.appinspect_api_password)
-            
+            #conf_output.inspectAppCLI()
+            if input_dto.splunk_api_username and input_dto.splunk_api_password:
+                _ = conf_output.inspectAppAPI(input_dto.splunk_api_username, input_dto.splunk_api_password, input_dto.stack_type)
+                
             print(f'Generate of security content successful to {conf_output.output_path}')
             return director_output_dto
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "3.3.0"
+version = "3.4.0"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
ACS support has now been added to contentctl for both Classic and Victoria Stacks which support Automated Private App Vetting (APAV)!

ACS deployment can be accomplished by FIRST building your app. After it has been built, the following command will ACS Deploy your app into your cloud stack:

```
usage: contentctl acs_deploy [-h] --splunk_api_username SPLUNK_API_USERNAME --splunk_api_password SPLUNK_API_PASSWORD --splunk_cloud_jwt_token SPLUNK_CLOUD_JWT_TOKEN --splunk_cloud_stack SPLUNK_CLOUD_STACK --stack_type {classic,victoria}

optional arguments:
  -h, --help            show this help message and exit
  --splunk_api_username SPLUNK_API_USERNAME
                        Username for running AppInspect and, if desired, installing your app via Admin Config Service (ACS). For documentation, please review https://dev.splunk.com/enterprise/reference/appinspect/appinspectapiepref and
                        https://docs.splunk.com/Documentation/SplunkCloud/9.1.2308/Config/ManageApps
  --splunk_api_password SPLUNK_API_PASSWORD
                        Username for running AppInspect and, if desired, installing your app via Admin Config Service (ACS). For documentation, please review https://dev.splunk.com/enterprise/reference/appinspect/appinspectapiepref and
                        https://docs.splunk.com/Documentation/SplunkCloud/9.1.2308/Config/ManageApps
  --splunk_cloud_jwt_token SPLUNK_CLOUD_JWT_TOKEN
                        Target Splunk Cloud Stack JWT Token for app deployment. Note that your stack MUST Support Admin Config Server (ACS) and Automated Private App Vetting (APAV). For documentation, on creating this token, please review
                        https://docs.splunk.com/Documentation/SplunkCloud/9.1.2312/Security/CreateAuthTokens#Use_Splunk_Web_to_create_authentication_tokens
  --splunk_cloud_stack SPLUNK_CLOUD_STACK
                        Target Splunk Cloud Stack for app deployment. Note that your stack MUST Support Admin Config Server (ACS) and Automated Private App Vetting (APAV). For documentation, please review https://docs.splunk.com/Documentation/SplunkCloud/9.1.2308/Config/ManageApps
  --stack_type {classic,victoria}
                        Identifies your Splunk Cloud Stack as 'classic' or 'victoria' experience
```

Note that before attempting to deploy your app, an appinspect will automatically be performed for you.
If appinspect passes, the Token Returned from Appinspect will be used in submitting your App for installation.

Also note that the internal name of your app, contentctl.yml-->build-->name, MUST be unique and not conflict with any Splunkbase Apps.  Most notably, it should NOT conflict with the name of ES Content Update app which is `DA-ESS-ContentUpdate` internally.


