### PR TITLE
Ignore Comments when resolving Macros

### DIFF
--- a/contentctl/objects/macro.py
+++ b/contentctl/objects/macro.py
@@ -43,6 +43,12 @@ class Macro(BaseModel):
     
     @staticmethod
     def get_macros(text_field:str, all_macros: list[Macro], ignore_macros:set[str]=MACROS_TO_IGNORE)->Tuple[list[Macro], set[str]]:
+        #Remove any comments, allowing there to be macros (which have a single backtick) inside those comments
+        #If a comment ENDS in a macro, for example ```this is a comment with a macro `macro_here````
+        #then there is a small edge case where the regex below does not work properly.  If that is 
+        #the case, we edit the search slightly to insert a space
+        text_field = re.sub(r"\`\`\`\`", r"` ```", text_field)
+        text_field = re.sub(r"\`\`\`.*?\`\`\`", " ", text_field)
         
         macros_to_get = re.findall(r'`([^\s]+)`', text_field)
         #If macros take arguments, stop at the first argument.  We just want the name of the macro


### PR DESCRIPTION
A bug was identified by a user where comments in SPL were resolved as macro names.
Validating would fail since we were unable to find these macros.

Now, we use a regex-based solution to remove comment-text in SPL before attempting. 
to resolve all outstanding macros