### PR TITLE
Enable individual searches by default

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -99,7 +99,7 @@ action.sendtophantom.param.severity = {{ detection.deployment.phantom.severity |
 {% endif %}
 {% endif %}
 alert.digest_mode = 1
-{% if detection.disabled is defined %}
+{% if detection.enabled_by_default %}
 disabled = false
 {% else %}
 disabled = true


### PR DESCRIPTION
Based on a number of community requests, the following
PR allows a Detection to be enabled by default when an app 
is built.
This is accomplished by adding the value
`enabled_by_default: true` 
into a detection.

Please note that ONLY `type: production` searches (not experimental or deprecated)
can be enabled.
Searches that are enabled_by_default must also be `type: TTP`, `type: Anomaly`, or `type: Correlation`. 
They may NOT be `type: Hunting`.
Setting a non-production or Hunting search to enabled_by_default will throw a descriptive error during validation. 

if the key `enabled_by_default` is NOT supplied in the Detection YML, it will default to `false`, maintaining previous behavior. 