### PR TITLE
Update appinspect api check interval

### DIFF
--- a/contentctl/output/conf_output.py
+++ b/contentctl/output/conf_output.py
@@ -300,6 +300,10 @@ class ConfOutput:
             "Authorization": f"bearer {authorization_bearer}"
         }
         startTime = timeit.default_timer()
+        # the first time, wait for 40 seconds. subsequent times, wait for less.
+        # this is because appinspect takes some time to return, so there is no sense
+        # checking many times when we know it will take at least 40 seconds to run.
+        iteration_wait_time = 40
         while True:
             
             res = get(APPINSPECT_API_VALIDATION_STATUS, headers=headers)
@@ -307,7 +311,8 @@ class ConfOutput:
             status = res.json().get("status",None)
             if status in ["PROCESSING", "PREPARING"]:
                 print(f"[{self.getElapsedTime(startTime)}] Appinspect API is {status}...")
-                time.sleep(15)
+                time.sleep(iteration_wait_time)
+                iteration_wait_time = 1
                 continue
             elif status == "SUCCESS":
                 print(f"[{self.getElapsedTime(startTime)}] Appinspect API has finished!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "3.4.1"
+version = "3.4.2"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Wait for a static amount of time before checking
every second to see if the appinspect api has 
finished with results.  Do this to prevent overhwelming
the API in the first 40 seconds (appinspect will not finish
faster than this) while also getting the results as soon as
possible.