### PR TITLE
MITRE ATT&CK Enrichment Perf Improvement

### DIFF
--- a/contentctl/enrichments/attack_enrichment.py
+++ b/contentctl/enrichments/attack_enrichment.py
@@ -29,7 +29,7 @@ class AttackEnrichment():
             print(f"\r{'Client'.rjust(23)}: [{100:3.0f}%]...Done!", end="\n", flush=True)
             
             print(f"\r{'Enterprise'.rjust(23)}: [{0.0:3.0f}%]...", end="", flush=True)
-            all_enterprise = lift.get_enterprise(stix_format=False)
+            all_enterprise = lift.get_enterprise_techniques(stix_format=False)
             print(f"\r{'Enterprise'.rjust(23)}: [{100:3.0f}%]...Done!", end="\n", flush=True)
             
             print(f"\r{'Relationships'.rjust(23)}: [{0.0:3.0f}%]...", end="", flush=True)
@@ -40,8 +40,8 @@ class AttackEnrichment():
             enterprise_groups = lift.get_enterprise_groups()
             print(f"\r{'Groups'.rjust(23)}: [{100:3.0f}%]...Done!", end="\n", flush=True)
             
-            for index, technique in enumerate(all_enterprise['techniques']):
-                progress_percent = ((index+1)/len(all_enterprise['techniques'])) * 100
+            for index, technique in enumerate(all_enterprise_techniques):
+                progress_percent = ((index+1)/len(all_enterprise_techniques)) * 100
                 if (sys.stdout.isatty() and sys.stdin.isatty() and sys.stderr.isatty()):
                     print(f"\r\t{'MITRE Technique Progress'.rjust(23)}: [{progress_percent:3.0f}%]...", end="", flush=True)
                 apt_groups = []


### PR DESCRIPTION
This changes what we fetch for ATT&CK to things we actually use. In profiling, this drops the runtime with enrichment enabled significantly.

- `poetry run contentctl -p ../ --enable_enrichment build -t ssa`
  previously: 170 seconds
  after: 40.8 seconds
  get_attack_lookup() before: 165s (97.46% of total runtime)
  get_attack_lookup() after: 36.9s (90.44% of total runtime)

- `poetry run contentctl -p ../ --enable_enrichment build` (ESCU Build)
  full runtime previously: 130 seconds
  full runtime after: 68.8s
  get_attack_lookup() before: 99.6s (76.56% of total runtime)
  get_attack_lookup() after: 36.4s (52.89% of total runtime)

Exact numbers may differ, ymmv, etc. Profiling performed on an i9 Macbook Pro in a relatively warm room.

I think there's still some performance improvements to be found here, but this is a good start.