### PR TITLE
(Draft) - Generic  Drill down

### DIFF
--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -199,6 +199,7 @@ class Director():
         builder.addNist()
         builder.addDatamodel()
         builder.addRBA()
+        builder.addBasicDrilldown()
         builder.addProvidingTechnologies()
         builder.addNesFields()
         builder.addAnnotations()
@@ -221,6 +222,13 @@ class Director():
         # TODO: is there a better way to handle this? The `test` portion of the config is not defined for validate
         if (self.input_dto.config.test is not None) and (not self.input_dto.config.test.enable_integration_testing):
             builder.skipIntegrationTests()
+        
+        if builder.security_content_obj is not None and \
+           builder.security_content_obj.tags is not None and \
+           isinstance(builder.security_content_obj.tags.manual_test,str):
+            # Set all tests, both Unit AND Integration, to manual_test.  Note that integration test messages
+            # will intentionally overwrite the justification in the skipIntegrationTests call above. 
+            builder.skipAllTests(builder.security_content_obj.tags.manual_test)
 
 
     def constructSSADetection(self, builder: DetectionBuilder, file_path: str) -> None:

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -19,7 +19,7 @@ from contentctl.objects.baseline import Baseline
 from contentctl.objects.playbook import Playbook
 from contentctl.helper.link_validator import LinkValidator
 from contentctl.objects.enums import SecurityContentType
-
+from contentctl.objects.test_group import TestGroup
 
 class Detection_Abstract(SecurityContentObject):
     # contentType: SecurityContentType = SecurityContentType.detections
@@ -50,6 +50,7 @@ class Detection_Abstract(SecurityContentObject):
     lookups: list[Lookup] = []
     cve_enrichment: list = None
     splunk_app_enrichment: list = None
+    drilldown_objects: list = None
 
     source: str = None
     nes_fields: str = None
@@ -59,6 +60,34 @@ class Detection_Abstract(SecurityContentObject):
 
     class Config:
         use_enum_values = True
+
+
+    # A list of groups of tests, relying on the same data
+    test_groups: Union[list[TestGroup], None] = None
+
+    @validator("test_groups", always=True)
+    def validate_test_groups(cls, value, values) -> Union[list[TestGroup], None]:
+        """
+        Validates the `test_groups` field and constructs the model from the list of unit tests
+        if no explicit construct was provided
+        :param value: the value of the field `test_groups`
+        :param values: a dict of the other fields in the Detection model
+        """
+        # if the value was not the None default, do nothing
+        if value is not None:
+            return value
+
+        # iterate over the unit tests and create a TestGroup (and as a result, an IntegrationTest) for each
+        test_groups: list[TestGroup] = []
+        for unit_test in values["tests"]:
+            test_group = TestGroup.derive_from_unit_test(unit_test, values["name"])
+            test_groups.append(test_group)
+
+        # now add each integration test to the list of tests
+        for test_group in test_groups:
+            values["tests"].append(test_group.integration_test)
+        return test_groups
+
 
     def get_content_dependencies(self) -> list[SecurityContentObject]:
         return self.playbooks + self.baselines + self.macros + self.lookups
@@ -194,16 +223,39 @@ class Detection_Abstract(SecurityContentObject):
         # Found everything
         return v
 
-    # TODO (cmcginley): Fix detection_abstract.tests_validate so that it surfaces validation errors
-    #   (e.g. a lack of tests) to the final results, instead of just showing a failed detection w/
-    #   no tests (maybe have a message propagated at the detection level? do a separate coverage
-    #   check as part of validation?):
-    @validator("tests")
+    @validator("tests", always=True)
     def tests_validate(cls, v, values):
-        if values.get("status", "") == DetectionStatus.production.value and not v:
-            raise ValueError(
-                "At least one test is REQUIRED for production detection: " + values["name"]
-            )
+        # TODO (cmcginley): Fix detection_abstract.tests_validate so that it surfaces validation errors
+        #   (e.g. a lack of tests) to the final results, instead of just showing a failed detection w/
+        #   no tests (maybe have a message propagated at the detection level? do a separate coverage
+        #   check as part of validation?):
+    
+    
+        #Only production analytics require tests
+        if values.get("status","") != DetectionStatus.production.value:
+            return v
+        
+        # All types EXCEPT Correlation MUST have test(s). Any other type, including newly defined types, requires them.
+        # Accordingly, we do not need to do additional checks if the type is Correlation
+        if values.get("type","") in set([AnalyticsType.Correlation.value]):
+            return v
+        
+            
+        # Ensure that there is at least 1 test        
+        if len(v) == 0:
+            if values.get("tags",None) and values.get("tags").manual_test is not None:
+                # Detections that are manual_test MAY have detections, but it is not required.  If they
+                # do not have one, then create one which will be a placeholder.
+                # Note that this fake UnitTest (and by extension, Integration Test) will NOT be generated
+                # if there ARE test(s) defined for a Detection.
+                placeholder_test = UnitTest(name="PLACEHOLDER FOR DETECTION TAGGED MANUAL_TEST WITH NO TESTS SPECIFIED IN YML FILE", attack_data=[])
+                return [placeholder_test]
+            
+            else:
+                raise ValueError("At least one test is REQUIRED for production detection: " + values.get("name", "NO NAME FOUND"))
+
+
+        #No issues - at least one test provided for production type requiring testing
         return v
 
     @validator("datamodel")

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -70,7 +70,7 @@ schedule_window = {{ detection.deployment.scheduling.schedule_window }}
 {% if detection.deployment is defined %}
 {% if detection.deployment.notable.rule_title is defined %}
 action.notable = 1 
-{% if detection.drilldown_objects is defined  and detection.drilldown_objects != [{}] %}
+{% if detection.drilldown_objects is defined  and detection.drilldown_objects != [{}] and detection.type | lower == "ttp" %}
 action.notable.param.drilldown_searches = {{ detection.drilldown_objects | tojson }}
 {% endif %}
 {% if detection.nes_fields is defined %}

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -69,7 +69,10 @@ schedule_window = {{ detection.deployment.scheduling.schedule_window }}
 {% endif %}
 {% if detection.deployment is defined %}
 {% if detection.deployment.notable.rule_title is defined %}
-action.notable = 1
+action.notable = 1 
+{% if detection.drilldown_objects is defined  and detection.drilldown_objects != [{}] %}
+action.notable.param.drilldown_searches = {{ detection.drilldown_objects | tojson }}
+{% endif %}
 {% if detection.nes_fields is defined %}
 action.notable.param.nes_fields = {{ detection.nes_fields }}
 {% endif %}
@@ -99,7 +102,7 @@ action.sendtophantom.param.severity = {{ detection.deployment.phantom.severity |
 {% endif %}
 {% endif %}
 alert.digest_mode = 1
-{% if detection.enabled_by_default %}
+{% if detection.disabled is defined %}
 disabled = false
 {% else %}
 disabled = true


### PR DESCRIPTION
Based on this feature request - 

https://github.com/splunk/security_content/issues/2385

This PR adds a drill down config to view the specific event for for all TTP detections that have a `risk_object = system` defined in their detection objects.


Example Config:
![image](https://github.com/splunk/contentctl/assets/7771446/58825e3a-2502-4f28-9f7f-706a7caf55b7)
