### PR TITLE
Updated GH Actions due to deprecations

### DIFF
--- a/.github/workflows/pushToPyPiOnRelease.yml
+++ b/.github/workflows/pushToPyPiOnRelease.yml
@@ -11,11 +11,11 @@ jobs:
 
       #Checkout the current branch
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #Install the given version of Python we will test against
       - name: Install Required Python Version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           architecture: "x64"

--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -30,11 +30,11 @@ jobs:
 
       #Checkout the current branch
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       #Install the given version of Python we will test against
       - name: Install Required Python Version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
           architecture: "x64"
@@ -69,7 +69,7 @@ jobs:
           cd my_splunk_content_pack
           poetry run contentctl test --unattended
       
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: content_pack_${{ matrix.python_version }}_${{ matrix.operating_system }}
           path: |


### PR DESCRIPTION
Every Actions run is currently surfacing multiple annotations due to deprecated Node actions:

![Screenshot 2024-04-12 at 12 39 15 PM](https://github.com/splunk/contentctl/assets/1413514/9db8ec8f-6a8c-4177-82da-28749c183138)

This PR bumps the versions on `.github/workflows/testEndToEnd.yml` and `.github/workflows/pushToPyPiOnRelease.yml` so that these won't be present going forward.