### PR TITLE
Fix potential whitespace issues

### DIFF
--- a/contentctl/output/conf_writer.py
+++ b/contentctl/output/conf_writer.py
@@ -34,7 +34,7 @@ class ConfWriter():
         # Failing to do so will result in an improperly formatted conf files that
         # cannot be parsed
         if isinstance(obj,str):
-            return obj.replace(f"\n","\\\n")
+            return obj.replace(f"\n"," \\\n")
         else:
             return obj
 

--- a/contentctl/output/templates/es_investigations_investigations.j2
+++ b/contentctl/output/templates/es_investigations_investigations.j2
@@ -7,14 +7,14 @@ disabled = 0
 tokens = {\
 {% for token in response_task.inputs %}
 {% if token == 'user' %}
-  "user": {\
-    "valuePrefix": "\"",\
-    "valueSuffix": "\"",\
-    "delimiter": " OR {{ token }}=",\
-    "valueType": "primitive",\
-    "value": "identity",\
-    "default": "null"\
-    }\{% elif token == 'dest'%}
+    "user": {\
+      "valuePrefix": "\"",\
+      "valueSuffix": "\"",\
+      "delimiter": " OR {{ token }}=",\
+      "valueType": "primitive",\
+      "value": "identity",\
+      "default": "null"\
+    }{% elif token == 'dest'%}
     "dest": {\
       "valuePrefix": "\"",\
       "valueSuffix": "\"",\
@@ -22,7 +22,7 @@ tokens = {\
       "valueType": "primitive",\
       "value": "asset",\
       "default": "null"\
-    }\{% else %}
+    }{% else %}
     "{{ token }}": {\
       "valuePrefix": "\"",\
       "valueSuffix": "\"",\
@@ -30,9 +30,9 @@ tokens = {\
       "valueType": "primitive",\
       "value": "file",\
       "default": "null"\
-    }\{% endif %}{{ "," if not loop.last }}
+    }{% endif %}{{ "," if not loop.last }}\
 {% endfor %}
-  }\
+}\
 
 
 {% endfor %}


### PR DESCRIPTION
This set of changes fixes potential issues with whitespace when 
serializing conf files.
These errors may be detected by btool when parsing conf files.