### PR TITLE
Removing Bias Language and updating templates

### DIFF
--- a/contentctl/templates/app_template/default/distsearch.conf
+++ b/contentctl/templates/app_template/default/distsearch.conf
@@ -1,5 +1,0 @@
-[replicationSettings:refineConf]
-replicate.analytic_stories = false
-
-[replicationDenylist]
-excludeESCU = apps[/\\]DA-ESS-ContentUpdate[/\\]lookups[/\\]...

--- a/contentctl/templates/app_template/default/distsearch.conf
+++ b/contentctl/templates/app_template/default/distsearch.conf
@@ -1,5 +1,5 @@
 [replicationSettings:refineConf]
 replicate.analytic_stories = false
 
-[replicationBlacklist]
+[replicationDenylist]
 excludeESCU = apps[/\\]DA-ESS-ContentUpdate[/\\]lookups[/\\]...


### PR DESCRIPTION
Renamed `[replicationBlacklist]` to `[replicationDenylist]` per documentation.

While working on that, I realized we have hardcoded references to `DA-ESS-ContentUpdate` and `ESCU` in the distsearch.conf template. We should figure a way to remove those as part of this too. Alternatively, we could remove it entirely and let folks decide when to add their own replication denylist by hand, when they need it, covering the files they need.