### PR TITLE
Cleaning up output order

### DIFF
--- a/contentctl/actions/new_content.py
+++ b/contentctl/actions/new_content.py
@@ -25,7 +25,8 @@ class NewContent:
         answers['date'] = datetime.today().strftime('%Y-%m-%d')
         answers['author'] = answers['detection_author']
         del answers['detection_author']
-        answers['data_source'] = answers['data_source']
+        answers['data_sources'] = answers['data_source']
+        del answers['data_source']
         answers['type'] = answers['detection_type']
         del answers['detection_type']
         answers['status'] = "production" #start everything as production since that's what we INTEND the content to become   
@@ -49,6 +50,7 @@ class NewContent:
         answers['tags']['required_fields'] = ['UPDATE']
         answers['tags']['risk_score'] = 'UPDATE (impact * confidence)/100'
         answers['tags']['security_domain'] = answers['security_domain']
+        del answers["security_domain"]
         answers['tags']['cve'] = ['UPDATE WITH CVE(S) IF APPLICABLE']
         
         #generate the tests section
@@ -64,6 +66,7 @@ class NewContent:
                 ]
             }
         ]
+        del answers["mitre_attack_ids"]
         return answers
 
     def buildStory(self)->dict[str,Any]:
@@ -111,12 +114,12 @@ class NewContent:
             #make sure the output folder exists for this detection
             output_folder.mkdir(exist_ok=True)
 
-            YmlWriter.writeYmlFile(file_path, object)
+            YmlWriter.writeDetection(file_path, object)
             print("Successfully created detection " + file_path)
         
         elif type == NewContentType.story:
             file_path = os.path.join(self.output_path, 'stories', self.convertNameToFileName(object['name'], object['tags']['product']))
-            YmlWriter.writeYmlFile(file_path, object)
+            YmlWriter.writeStory(file_path, object)
             print("Successfully created story " + file_path)        
         
         else:

--- a/contentctl/output/yml_writer.py
+++ b/contentctl/output/yml_writer.py
@@ -9,3 +9,41 @@ class YmlWriter:
 
         with open(file_path, 'w') as outfile:
             yaml.safe_dump(obj, outfile, default_flow_style=False, sort_keys=False)
+
+    @staticmethod
+    def writeDetection(file_path: str, obj: dict[Any,Any]) -> None:
+        output = dict()
+        output["name"] = obj["name"]
+        output["id"] = obj["id"]
+        output["version"] = obj["version"]
+        output["date"] = obj["date"]
+        output["author"] = obj["author"]
+        output["type"] = obj["type"]
+        output["status"] = obj["status"]
+        output["data_source"] = obj['data_sources']
+        output["description"] = obj["description"]
+        output["search"] = obj["search"]
+        output["how_to_implement"] = obj["how_to_implement"]
+        output["known_false_positives"] = obj["known_false_positives"]
+        output["references"] = obj["references"]
+        output["tags"] = obj["tags"]
+        output["tests"] = obj["tags"]
+
+        YmlWriter.writeYmlFile(file_path=file_path, obj=output)
+ 
+    @staticmethod
+    def writeStory(file_path: str, obj: dict[Any,Any]) -> None:
+        output = dict()
+        output['name'] = obj['name']
+        output['id'] = obj['id']
+        output['version'] = obj['version']
+        output['date'] = obj['date']
+        output['author'] = obj['author']
+        output['description'] = obj['description']
+        output['narrative'] = obj['narrative']
+        output['references'] = obj['references']
+        output['tags'] = obj['tags']
+
+        YmlWriter.writeYmlFile(file_path=file_path, obj=output)
+ 
+


### PR DESCRIPTION
1) Removes extra fields that we don't want that were missed before
2) sorts the output! Technically, order doesn't matter in YAML. But given that we're generating a skeleton that we expect people to manually add/edit, we should create a file that's consistent with what we expect.