### PR TITLE
Add verbose error option

### DIFF
--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -1,5 +1,10 @@
-from contentctl.actions.initialize import Initialize
+import traceback
+import sys
+import warnings
+import pathlib
 import tyro
+
+from contentctl.actions.initialize import Initialize
 from contentctl.objects.config import init, validate, build,  new, deploy_acs, deploy_rest, test, test_servers, inspect, report, test_common, release_notes
 from contentctl.actions.validate import Validate
 from contentctl.actions.new_content import NewContent
@@ -9,14 +14,10 @@ from contentctl.actions.build import (
      DirectorOutputDto,
      Build,
 )
-
 from contentctl.actions.test import Test
 from contentctl.actions.test import TestInputDto
 from contentctl.actions.reporting import ReportingInputDto, Reporting
 from contentctl.actions.inspect import Inspect
-import sys
-import warnings
-import pathlib
 from contentctl.input.yml_reader import YmlReader
 from contentctl.actions.release_notes import ReleaseNotes
 
@@ -183,7 +184,7 @@ def main():
 
 
    
-    
+    config = None
     try:
         # Since some model(s) were constructed and not model_validated, we have to catch
         # warnings again when creating the cli
@@ -220,9 +221,16 @@ def main():
         else:
             raise Exception(f"Unknown command line type '{type(config).__name__}'")
     except Exception as e:
-        import traceback
-        traceback.print_exc()
-        traceback.print_stack()
-        #print(e)
+        if config is None:
+            print("There was a serious issue where the config file could not be created.\n"
+                  "The entire stack trace is provided below (please include it if filing a bug report).\n")
+            traceback.print_exc()
+        elif config.verbose:
+            print("Verbose logging is enabled.\n"
+                  "The entire stack trace has been provided below (please include it if filing a bug report):\n")
+            traceback.print_exc()
+        else:
+            print(e)
+            
         sys.exit(1)
     

--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -226,10 +226,12 @@ def main():
                   "The entire stack trace is provided below (please include it if filing a bug report).\n")
             traceback.print_exc()
         elif config.verbose:
-            print("Verbose logging is enabled.\n"
+            print("Verbose error logging is ENABLED.\n"
                   "The entire stack trace has been provided below (please include it if filing a bug report):\n")
             traceback.print_exc()
         else:
+            print("Verbose error logging is DISABLED.\n"
+                  "Please use the --verbose command line argument if you need more context for your error or file a bug report.")
             print(e)
             
         sys.exit(1)

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -154,6 +154,10 @@ class Config_Base(BaseModel):
 
     path: DirectoryPath = Field(default=DirectoryPath("."), description="The root of your app.")
     app:CustomApp = Field(default_factory=CustomApp)
+    verbose:bool = Field(default=False, description="Enable verbose error logging, including a stacktrace. "
+                         "This option makes debugging contentctl errors much easier, but produces way more "
+                         "output than is useful under most uses cases. "
+                         "Please use this flag if you are submitting a bug report or issue on GitHub.")
     
     @field_serializer('path',when_used='always')
     def serialize_path(path: DirectoryPath)->str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.0.5"
+version = "4.0.6"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
By default, output shorter, more meaningful message when running 
contentctl operations like validate, build, etc.

Only show longer error outputs when the --verbose command line argument is given.

This makes it much easier to understand why your operations are failing as most errors are 
generated from Pydantic Exceptions around improperly constructed content.