### PR TITLE
Emit summary if no detections tested

### DIFF
--- a/contentctl/actions/test.py
+++ b/contentctl/actions/test.py
@@ -90,6 +90,9 @@ class Test:
         
         if len(input_dto.detections) == 0:
             print(f"With Detection Testing Mode '{input_dto.config.getModeName()}', there were [0] detections found to test.\nAs such, we will quit immediately.")
+            # Directly call stop so that the summary.yml will be generated. Of course it will not have any test results, but we still want it to contain
+            # a summary showing that now detections were tested.
+            file.stop()
         else:
             print(f"MODE: [{input_dto.config.getModeName()}] - Test [{len(input_dto.detections)}] detections")
             if input_dto.config.mode in [DetectionTestingMode.changes, DetectionTestingMode.selected]:
@@ -98,7 +101,7 @@ class Test:
 
             manager.setup()
             manager.execute()
-
+        
         try:
             summary_results = file.getSummaryObject()
             summary = summary_results.get("summary", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.1.0"
+version = "4.1.1"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
We still want to emit a test_results/summary.yml file, even if there were no detections tested.
We should always have a record of the test. Here is what it will look like if no tests were run:

```
summary:
  success: true
  total_detections: 0
  total_pass: 0
  total_fail: 0
  total_skipped: 0
  total_untested: 0
  total_experimental_or_deprecated: 0
  success_rate: UKNOWN
tested_detections: []
untested_detections: []
percent_complete: UKNOWN
deprecated_detections: []
experimental_detections: []
```

This is very common when using mode:changes against the same branch or a branch with no updates that can be tested.