### PR TITLE
Fix checking during mode:changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.1.1"
+version = "4.1.2"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
Fix bug where a detection that changed
would not be tested if it contained the
string "dist" in the name.  This was due
to how we checked whether or not
modified content was in the appropriate
content folders like detections, macros,
and lookups or whether it was in a folder
like dist/ or app_template.  The way this
checking is done is now improved so we
examine the paths using is_relative_to
instead of looking for a substring in the
path.