### PR TITLE
Small Model Tweak

### DIFF
--- a/contentctl/objects/detection_tags.py
+++ b/contentctl/objects/detection_tags.py
@@ -31,7 +31,7 @@ class DetectionTags(BaseModel):
         return round((self.confidence * self.impact)/100)
     
     
-    mitre_attack_id: List[Annotated[str, Field(pattern="^T\d{4}(.\d{3})?$")]] = []
+    mitre_attack_id: List[Annotated[str, Field(pattern="^T[0-9]{4}(.[0-9]{3})?$")]] = []
     nist: list[NistCategory] = []
     observable: List[Observable] = []
     message: Optional[str] = Field(...)
@@ -138,6 +138,7 @@ class DetectionTags(BaseModel):
             "risk_score": self.risk_score,
             "security_domain": self.security_domain,
             "risk_severity": self.risk_severity,
+            "mitre_attack_ids": self.mitre_attack_id,
             "mitre_attack_enrichments": self.mitre_attack_enrichments
         }
     

--- a/contentctl/objects/detection_tags.py
+++ b/contentctl/objects/detection_tags.py
@@ -138,7 +138,7 @@ class DetectionTags(BaseModel):
             "risk_score": self.risk_score,
             "security_domain": self.security_domain,
             "risk_severity": self.risk_severity,
-            "mitre_attack_ids": self.mitre_attack_id,
+            "mitre_attack_id": self.mitre_attack_id,
             "mitre_attack_enrichments": self.mitre_attack_enrichments
         }
     


### PR DESCRIPTION
Adding the `mitre_attack_id` field back to the detection tags model so that SSE doesn't break- Their move to support the new API did not include support for the `tag.mitre_attack_enrichments[]` object, so sometimes our content just doesn't show up as mapped without this.  

Also tweaked the regex in `mitre_attack_id` because I was getting runtime errors on the use of `\d` to grab digits.