### PR TITLE
Handling the case where there are no tests

### DIFF
--- a/contentctl/actions/detection_testing/GitService.py
+++ b/contentctl/actions/detection_testing/GitService.py
@@ -155,21 +155,22 @@ class GitService(BaseModel):
         print(f"[{len(updated_detections)}] Pieces of modifed and new content (this may include experimental/deprecated/manual_test content):\n - {modifiedAndNewContentString}")
         return updated_detections
 
-    def getSelected(self, detectionFilenames:List[FilePath])->List[Detection]:
-        filepath_to_content_map:dict[FilePath, SecurityContentObject] = { obj.file_path:obj for (_,obj) in self.director.name_to_content_map.items() if obj.file_path is not None} 
+    def getSelected(self, detectionFilenames: List[FilePath]) -> List[Detection]:
+        filepath_to_content_map: dict[FilePath, SecurityContentObject] = {
+        obj.file_path: obj for (_, obj) in self.director.name_to_content_map.items() if obj.file_path is not None
+    }
         errors = []
-        detections:List[Detection] = []
+        detections: List[Detection] = []
         for name in detectionFilenames:
-            obj = filepath_to_content_map.get(name,None)
-            if obj == None:
+            obj = filepath_to_content_map.get(name, None)
+            if obj is None:
                 errors.append(f"There is no detection file or security_content_object at '{name}'")
             elif not isinstance(obj, Detection):
                 errors.append(f"The security_content_object at '{name}' is of type '{type(obj).__name__}', NOT '{Detection.__name__}'")
             else:
                 detections.append(obj)
 
-        if len(errors) > 0:
+        if errors:
             errorsString = "\n - ".join(errors)
-            raise Exception(f"There following errors were encountered while getting selected detections to test:\n - {errorsString}")
+            raise Exception(f"The following errors were encountered while getting selected detections to test:\n - {errorsString}")
         return detections
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.2.0"
+version = "4.2.1"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
If there's no tests, `data.info.get("tests")` returns None, which it then can't add integration tests to, so changing it slightly.

Also, assuming that at some point someone's checked that `info.data["name"]` is valid, since `info.data.get("name")` possibly returns None, which made the type-checker sad.