### PR TITLE
Create threat objects for threat objects

### DIFF
--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -285,6 +285,11 @@ class Detection_Abstract(SecurityContentObject):
                 risk_object['threat_object_type'] = "url"
                 risk_objects.append(risk_object) 
 
+            elif 'Attacker' in entity.role:
+                risk_object['threat_object_field'] = entity.name
+                risk_object['threat_object_type'] = entity.type.lower()
+                risk_objects.append(risk_object)
+
             else:
                 risk_object['risk_object_type'] = 'other'
                 risk_object['risk_object_field'] = entity.name


### PR DESCRIPTION
There was a condition in which a field listed as an attacker (which **should** be translated to a Threat Object) was being converted into a Risk Object instead. 

This changes that, so that all observables listed as attackers will be threat objects. 

Because ES creates a risk event for each pair of risk objects and threat objects (1 risk and 3 threats will create 3 risk events, 2 risk and 3 threats will create 6 risk events, etc), this also has the benefit of reducing the total amount of risk events created under our system. 

Relatedly, we no longer need to fail testing if every event in a result set does not have **all** of the fields listed in the observable. The multiplexing, essentially, of raw search results into risk events means that we should only really require each observable to be present _somewhere_ in the dataset. (The change implementing this is not yet in this PR)