### PR TITLE
SA Admon lookup exclusion

### DIFF
--- a/contentctl/objects/lookup.py
+++ b/contentctl/objects/lookup.py
@@ -8,13 +8,14 @@ if TYPE_CHECKING:
     from contentctl.objects.config import validate
 from contentctl.objects.security_content_object import SecurityContentObject
 
-
+# This section is used to ignore lookups that are NOT  shipped with ESCU app but are used in the detections. Adding exclusions here will so that contentctl builds will not fail.
 LOOKUPS_TO_IGNORE = set(["outputlookup"])
 LOOKUPS_TO_IGNORE.add("ut_shannon_lookup") #In the URL toolbox app which is recommended for ESCU
 LOOKUPS_TO_IGNORE.add("identity_lookup_expanded") #Shipped with the Asset and Identity Framework
 LOOKUPS_TO_IGNORE.add("cim_corporate_web_domain_lookup") #Shipped with the Asset and Identity Framework
 LOOKUPS_TO_IGNORE.add("alexa_lookup_by_str") #Shipped with the Asset and Identity Framework
 LOOKUPS_TO_IGNORE.add("interesting_ports_lookup") #Shipped with the Asset and Identity Framework
+LOOKUPS_TO_IGNORE.add("admon_groups_def") #Shipped with the SA-admon addon
 
 #Special case for the Detection "Exploit Public Facing Application via Apache Commons Text"
 LOOKUPS_TO_IGNORE.add("=") 


### PR DESCRIPTION
This PR is failing on contentctl build for https://github.com/splunk/security_content/pull/3026 , since there is a detection which this lookup `admon_groups_def` which not present in the ESCU app. 

The lookup is shipped by another app called : `SA-admon`. Hence adding it to this exclusion list! 

