### PR TITLE
make labels a bit shorter

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -57,15 +57,7 @@ cron_schedule = {{ detection.deployment.scheduling.cron_schedule }}
 dispatch.earliest_time = {{ detection.deployment.scheduling.earliest_time }}
 dispatch.latest_time = {{ detection.deployment.scheduling.latest_time }}
 action.correlationsearch.enabled = 1
-{% if detection.status == "deprecated" %}
-action.correlationsearch.label = {{APP_NAME}} - Deprecated - {{ detection.name }} - Rule
-{% elif detection.status == "experimental" %}
-action.correlationsearch.label = {{APP_NAME}} - Experimental - {{ detection.name }} - Rule
-{% elif detection.type | lower == "correlation" %}
-action.correlationsearch.label = {{APP_NAME}} - RIR - {{ detection.name }} - Rule
-{% else %}
 action.correlationsearch.label = {{APP_NAME}} - {{ detection.name }} - Rule
-{% endif %}
 action.correlationsearch.annotations = {{ detection.annotations | tojson }}
 action.correlationsearch.metadata = {{ detection.getMetadata() | tojson }}
 {% if detection.deployment.scheduling.schedule_window is defined %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.2.1"
+version = "4.2.2"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
We need to prevent the labels for the name of a search from being too long because it can cause issues in the user interface.
As such, we have removed the words `- Experimental -`, `- Deprecated -`, and `- RIR -` from the `action.correlationsearch.label` field in savedsearches.conf.