### PR TITLE
Allow `contentctl test` to work on Windows by fixing a path problem.

### DIFF
--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12"]
-        operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest", "macos-14"]
+        operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest", "macos-14", "windows-2022"]
         #operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest"]
 
 

--- a/.github/workflows/test_against_escu.yml
+++ b/.github/workflows/test_against_escu.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12"]
-        operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest", "macos-14"]
+        operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest", "macos-14", "windows-2022"]
         #operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest"]
 
 

--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
@@ -75,7 +75,7 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
         mounts = [
             docker.types.Mount(
                 source=str(self.global_config.getLocalAppDir()),
-                target=str(self.global_config.getContainerAppDir()),
+                target=(self.global_config.getContainerAppDir()).as_posix(),
                 type="bind",
                 read_only=True,
             )

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -601,13 +601,13 @@ class test_common(build):
 
 
     def getLocalAppDir(self)->pathlib.Path:
-        #docker really wants abolsute paths
+        # docker really wants absolute paths
         path = self.path / "apps"
         return path.absolute()
     
     def getContainerAppDir(self)->pathlib.Path:
-        #docker really wants abolsute paths
-        return pathlib.Path("/tmp/apps").absolute()
+        # docker really wants absolute paths
+        return pathlib.Path("/tmp/apps")
 
     def enterpriseSecurityInApps(self)->bool:
         
@@ -739,7 +739,7 @@ class test(test_common):
             if path.startswith(SPLUNKBASE_URL):
                 container_paths.append(path)
             else:
-                container_paths.append(str(self.getContainerAppDir()/pathlib.Path(path).name))
+                container_paths.append((self.getContainerAppDir()/pathlib.Path(path).name).as_posix())
         
         return ','.join(container_paths)
 


### PR DESCRIPTION
When using `contentctl test` on Windows, a wrong path is generated. We need to force this path to be a posix path else we have an error that looks like this:

```
400 Client Error for http+docker://localnpipe/v1.46/containers/create?name=contentctl_0&platform=linux%2Famd64: Bad Request ("invalid mount config for type "bind": invalid mount path: 'C:/tmp/apps' mount path must be absolute"
```

This should not have an impact on Linux systems, but I have not tested myself.