### PR TITLE
Update on naming for the repo readme vs app readme

### DIFF
--- a/contentctl/actions/initialize.py
+++ b/contentctl/actions/initialize.py
@@ -37,8 +37,9 @@ class Initialize:
             #Throw an exception if the target exists
             shutil.copytree(source_directory, target_directory, dirs_exist_ok=False)
         
-        #Create the config file as well
-        shutil.copyfile(pathlib.Path(os.path.dirname(__file__))/'../templates/README','README')
+        # Create a README.md file.  Note that this is the README.md for the repository, not the
+        # one which will actually be packaged into the app. That is located in the app_template folder.
+        shutil.copyfile(pathlib.Path(os.path.dirname(__file__))/'../templates/README.md','README.md')
 
 
         print(f"The app '{config.app.title}' has been initialized. "

--- a/contentctl/output/conf_output.py
+++ b/contentctl/output/conf_output.py
@@ -169,15 +169,8 @@ class ConfOutput:
     
     def packageAppSlim(self) -> None:
         
-
-        # input_app_path = pathlib.Path(self.config.build.path_root)/f"{self.config.build.name}"
-        
-        # readme_file = pathlib.Path("README")
-        # if not readme_file.is_file():
-        #     raise Exception("The README file does not exist in this directory. Cannot build app.")
-        # shutil.copyfile(readme_file, input_app_path/readme_file.name)
-        
-        
+        raise Exception("Packaging with splunk-packaging-toolkit not currently supported as slim only supports Python 3.7. "
+                        "Please raise an issue in the contentctl GitHub if you encounter this exception.")
         try:
             import slim
             from slim.utils import SlimLogger

--- a/contentctl/templates/README
+++ b/contentctl/templates/README
@@ -1,2 +1,0 @@
-This README file was automatically created by contentctl init. 
-Please fill it with meaningful information that describes your app.  

--- a/contentctl/templates/README.md
+++ b/contentctl/templates/README.md
@@ -1,0 +1,10 @@
+# Contentctl App Readme
+
+This README file was automatically created by contentctl init. 
+Please fill it with meaningful information that describes your app.  
+
+Note that this file can contain Markdown and will be richly rendered in GitHub or most other Version Control Systems.
+
+
+Note: This readme file is actually DIFFERENT from the one that will be packaged as part of your App.
+That file is located at app_template/README.md.


### PR DESCRIPTION
Repo and app readme are are actually
different. Also make any usage of the slim
packaging feature generate an exception.