### PR TITLE
Remove Use of Deprecated @validator and Config class

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructure.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructure.py
@@ -14,7 +14,7 @@ from sys import stdout
 from shutil import copyfile
 from typing import Union, Optional
 
-from pydantic import BaseModel, PrivateAttr, Field, dataclasses
+from pydantic import ConfigDict, BaseModel, PrivateAttr, Field, dataclasses
 import requests                                                                                     # type: ignore
 import splunklib.client as client                                                                   # type: ignore
 from splunklib.binding import HTTPError                                                             # type: ignore
@@ -49,9 +49,7 @@ class SetupTestGroupResults(BaseModel):
     success: bool = True
     duration: float = 0
     start_time: float
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class CleanupTestGroupResults(BaseModel):
@@ -86,9 +84,7 @@ class DetectionTestingInfrastructure(BaseModel, abc.ABC):
     _conn: client.Service = PrivateAttr()
     pbar: tqdm.tqdm = None
     start_time: Optional[float] = None
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/contentctl/actions/detection_testing/views/DetectionTestingViewWeb.py
+++ b/contentctl/actions/detection_testing/views/DetectionTestingViewWeb.py
@@ -7,6 +7,7 @@ from wsgiref.simple_server import make_server, WSGIRequestHandler
 import jinja2
 import webbrowser
 from threading import Thread
+from pydantic import ConfigDict
 
 DEFAULT_WEB_UI_PORT = 7999
 
@@ -100,9 +101,7 @@ class SimpleWebServer(ServerAdapter):
 class DetectionTestingViewWeb(DetectionTestingView):
     bottleApp: Bottle = Bottle()
     server: SimpleWebServer = SimpleWebServer(host="0.0.0.0", port=DEFAULT_WEB_UI_PORT)
-
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def setup(self):
         self.bottleApp.route("/", callback=self.showStatus)

--- a/contentctl/enrichments/cve_enrichment.py
+++ b/contentctl/enrichments/cve_enrichment.py
@@ -5,7 +5,7 @@ import os
 import shelve
 import time
 from typing import Annotated, Any, Union, TYPE_CHECKING
-from pydantic import BaseModel,Field, computed_field
+from pydantic import ConfigDict, BaseModel,Field, computed_field
 from decimal import Decimal
 from requests.exceptions import ReadTimeout
 
@@ -33,12 +33,8 @@ class CveEnrichment(BaseModel):
     use_enrichment: bool = True
     cve_api_obj: Union[CVESearch,None] = None
     
-
-    class Config:
-        # Arbitrary_types are allowed to let us use the CVESearch Object
-        arbitrary_types_allowed = True
-        frozen = True
-        
+    # Arbitrary_types are allowed to let us use the CVESearch Object
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
     @staticmethod
     def getCveEnrichment(config:validate, timeout_seconds:int=10, force_disable_enrichment:bool=True)->CveEnrichment:

--- a/contentctl/objects/base_test_result.py
+++ b/contentctl/objects/base_test_result.py
@@ -1,7 +1,7 @@
 from typing import Union, Any
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 from splunklib.data import Record
 
 from contentctl.helper.utils import Utils
@@ -51,12 +51,9 @@ class BaseTestResult(BaseModel):
 
     # The Splunk endpoint URL
     sid_link: Union[None, str] = None
-
-    class Config:
-        validate_assignment = True
-
-        # Needed to allow for embedding of Exceptions in the model
-        arbitrary_types_allowed = True
+    
+    # Needed to allow for embedding of Exceptions in the model
+    model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
     @property
     def passed(self) -> bool:

--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -4,7 +4,7 @@ import json
 from typing import Union, Optional, Any
 from enum import Enum
 
-from pydantic import BaseModel, validator, Field, PrivateAttr
+from pydantic import ConfigDict, BaseModel, computed_field, Field, PrivateAttr
 from splunklib.results import JSONResultsReader, Message                                            # type: ignore
 from splunklib.binding import HTTPError, ResponseReader                                             # type: ignore
 import splunklib.client as splunklib                                                                # type: ignore
@@ -177,10 +177,9 @@ class PbarData(BaseModel):
     pbar: tqdm
     fq_test_name: str
     start_time: float
-
-    class Config:
-        # needed to support the tqdm type
-        arbitrary_types_allowed = True
+    
+    # needed to support the tqdm type
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class CorrelationSearch(BaseModel):

--- a/contentctl/objects/notable_event.py
+++ b/contentctl/objects/notable_event.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import ConfigDict, BaseModel
 
 from contentctl.objects.detection import Detection
 
@@ -10,11 +10,10 @@ class NotableEvent(BaseModel):
 
     # The search ID that found that generated this risk event
     orig_sid: str
-
-    class Config:
-        # Allowing fields that aren't explicitly defined to be passed since some of the risk event's
-        # fields vary depending on the SPL which generated them
-        extra = 'allow'
+    
+    # Allowing fields that aren't explicitly defined to be passed since some of the risk event's
+    # fields vary depending on the SPL which generated them
+    model_config = ConfigDict(extra='allow')
 
     def validate_against_detection(self, detection: Detection) -> None:
         raise NotImplementedError()

--- a/contentctl/objects/risk_analysis_action.py
+++ b/contentctl/objects/risk_analysis_action.py
@@ -1,7 +1,7 @@
 from typing import Any
 import json
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, field_validator
 
 from contentctl.objects.risk_object import RiskObject
 from contentctl.objects.threat_object import ThreatObject
@@ -21,32 +21,32 @@ class RiskAnalysisAction(BaseModel):
     risk_objects: list[RiskObject]
     message: str
 
-    @validator("message", always=True, pre=True)
+    @field_validator("message", mode="before")
     @classmethod
-    def _validate_message(cls, v, values) -> str:
+    def _validate_message(cls, message) -> str:
         """
         Validate splunk_path and derive if None
         """
-        if v is None:
+        if message is None:
             raise ValueError(
                 "RiskAnalysisAction.message is a required field, cannot be None. Check the "
                 "detection YAML definition to ensure a message is defined"
             )
 
-        if not isinstance(v, str):
+        if not isinstance(message, str):
             raise ValueError(
                 "RiskAnalysisAction.message must be a string. Check the detection YAML definition "
                 "to ensure message is defined as a string"
             )
 
-        if len(v.strip()) < 1:
+        if len(message.strip()) < 1:
             raise ValueError(
                 "RiskAnalysisAction.message must be a meaningful string, with a length greater than"
                 "or equal to 1 (once stripped of trailing/leading whitespace). Check the detection "
                 "YAML definition to ensure message is defined as a meanigful string"
             )
 
-        return v
+        return message
 
     @classmethod
     def parse_from_dict(cls, dict_: dict[str, Any]) -> "RiskAnalysisAction":

--- a/contentctl/objects/risk_event.py
+++ b/contentctl/objects/risk_event.py
@@ -1,7 +1,7 @@
 import re
 from typing import Union, Optional
 
-from pydantic import BaseModel, Field, PrivateAttr, field_validator
+from pydantic import ConfigDict, BaseModel, Field, PrivateAttr, field_validator
 
 from contentctl.objects.errors import ValidationFailed
 from contentctl.objects.detection import Detection
@@ -61,11 +61,10 @@ class RiskEvent(BaseModel):
 
     # Private attribute caching the observable this RiskEvent is mapped to
     _matched_observable: Optional[Observable] = PrivateAttr(default=None)
-
-    class Config:
-        # Allowing fields that aren't explicitly defined to be passed since some of the risk event's
-        # fields vary depending on the SPL which generated them
-        extra = "allow"
+    
+    # Allowing fields that aren't explicitly defined to be passed since some of the risk event's
+    # fields vary depending on the SPL which generated them
+    model_config = ConfigDict(extra="allow")
 
     @field_validator("annotations_mitre_attack", "analyticstories", mode="before")
     @classmethod

--- a/contentctl/objects/ssa_detection.py
+++ b/contentctl/objects/ssa_detection.py
@@ -3,7 +3,7 @@ import uuid
 import string
 import requests
 import time
-from pydantic import BaseModel, validator, root_validator
+from pydantic import ConfigDict, BaseModel, validator, root_validator
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Union
@@ -59,8 +59,7 @@ class SSADetection(BaseModel):
     #         raise ValueError('name is longer then 67 chars: ' + v)
     #     return v
 
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
     '''
     @validator("name")


### PR DESCRIPTION
Solves https://github.com/splunk/contentctl/issues/232. 

- NIST and Kill Chain Phases tag deprecated `@validator` were replaced by `@field_validator`
- All other deprecated `@validators` were replaced by `@computed_field`
- Deprecated `Config` class was replaced by `ConfigDict` object