### PR TITLE
Hotfix: Bumping integration testing timeout to compensate for recent bugfix

### DIFF
--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -105,7 +105,7 @@ class TimeoutConfig(int, Enum):
     BASE_SLEEP = 60
 
     # max amount to wait before timing out during exponential backoff
-    MAX_SLEEP = 210
+    MAX_SLEEP = 270
 
 
 # TODO (#226): evaluate sane defaults for timeframe for integration testing (e.g. 5y is good

--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -104,8 +104,12 @@ class TimeoutConfig(int, Enum):
     # base amount to sleep for before beginning exponential backoff during testing
     BASE_SLEEP = 60
 
-    # max amount to wait before timing out during exponential backoff
-    MAX_SLEEP = 270
+    # NOTE: Some detections take longer to generate their risk/notables than other; testing has
+    #   shown 270s to likely be sufficient for all detections in 99% of runs; however we have
+    #   encountered a handful of transient failures in the last few months. Since our success rate
+    #   is at 100% now, we will round this to a flat 300s to accomodate these outliers.
+    # Max amount to wait before timing out during exponential backoff
+    MAX_SLEEP = 300
 
 
 # TODO (#226): evaluate sane defaults for timeframe for integration testing (e.g. 5y is good


### PR DESCRIPTION
# Context
- in #92 we introduced a bugfix which shaved an unnecessary extra 60s wait before starting the backoff timer
- this resulted in less overall time for those detections which are sluggish to generate risk events, causing some intermittent failures

# Code changes
- we bumped the total backoff timer by 60s (from 210s to 270s)
