### PR TITLE
Abstract Commonly Used Annotated Type Definitions

### DIFF
--- a/contentctl/enrichments/attack_enrichment.py
+++ b/contentctl/enrichments/attack_enrichment.py
@@ -10,6 +10,7 @@ from dataclasses import field
 from typing import Annotated,Any
 from contentctl.objects.mitre_attack_enrichment import MitreAttackEnrichment
 from contentctl.objects.config import validate
+from contentctl.objects.annotated_types import MITRE_ATTACK_ID_TYPE
 logging.getLogger('taxii2client').setLevel(logging.CRITICAL)
 
 
@@ -23,7 +24,7 @@ class AttackEnrichment(BaseModel):
         _ = enrichment.get_attack_lookup(str(config.path))
         return enrichment
     
-    def getEnrichmentByMitreID(self, mitre_id:Annotated[str, Field(pattern=r"^T\d{4}(.\d{3})?$")])->MitreAttackEnrichment:
+    def getEnrichmentByMitreID(self, mitre_id:MITRE_ATTACK_ID_TYPE)->MitreAttackEnrichment:
         if not self.use_enrichment:
             raise Exception(f"Error, trying to add Mitre Enrichment, but use_enrichment was set to False")
         

--- a/contentctl/enrichments/cve_enrichment.py
+++ b/contentctl/enrichments/cve_enrichment.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any, Union, TYPE_CHECKING
 from pydantic import BaseModel,Field, computed_field
 from decimal import Decimal
 from requests.exceptions import ReadTimeout
-
+from contentctl.objects.annotated_types import CVE_TYPE
 if TYPE_CHECKING:
     from contentctl.objects.config import validate
 
@@ -18,7 +18,7 @@ CVESSEARCH_API_URL = 'https://cve.circl.lu'
 
 
 class CveEnrichmentObj(BaseModel):
-    id: Annotated[str, r"^CVE-[1|2]\d{3}-\d+$"]
+    id: CVE_TYPE
     cvss: Annotated[Decimal, Field(ge=.1, le=10, decimal_places=1)]
     summary: str
     

--- a/contentctl/objects/annotated_types.py
+++ b/contentctl/objects/annotated_types.py
@@ -1,0 +1,6 @@
+from pydantic import Field
+from typing import Annotated
+
+CVE_TYPE = Annotated[str, Field(pattern=r"^CVE-[1|2]\d{3}-\d+$")]
+MITRE_ATTACK_ID_TYPE = Annotated[str, Field(pattern=r"^T\d{4}(.\d{3})?$")]
+APPID_TYPE = Annotated[str,Field(pattern="^[a-zA-Z0-9_-]+$")]

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 from abc import ABC, abstractmethod
 from contentctl.objects.enums import PostTestBehavior, DetectionTestingMode
 from contentctl.objects.detection import Detection
-
+from contentctl.objects.annotated_types import APPID_TYPE
 import tqdm
 from functools import partialmethod
 
@@ -33,7 +33,7 @@ class App_Base(BaseModel,ABC):
     model_config = ConfigDict(use_enum_values=True,validate_default=True, arbitrary_types_allowed=True)
     uid: Optional[int] = Field(default=None)
     title: str = Field(description="Human-readable name used by the app. This can have special characters.")
-    appid: Optional[Annotated[str, Field(pattern="^[a-zA-Z0-9_-]+$")]]= Field(default=None,description="Internal name used by your app. "
+    appid: Optional[APPID_TYPE]= Field(default=None,description="Internal name used by your app. "
                                                                     "It may ONLY have characters, numbers, and underscores. No other characters are allowed.")
     version: str = Field(description="The version of your Content Pack.  This must follow semantic versioning guidelines.")
     description: Optional[str] = Field(default="description of app",description="Free text description of the Content Pack.")
@@ -101,7 +101,7 @@ class CustomApp(App_Base):
     # https://docs.splunk.com/Documentation/Splunk/9.0.4/Admin/Appconf
     uid: int = Field(ge=2, lt=100000, default_factory=lambda:random.randint(20000,100000))
     title: str = Field(default="Content Pack",description="Human-readable name used by the app. This can have special characters.")
-    appid: Annotated[str, Field(pattern="^[a-zA-Z0-9_-]+$")]= Field(default="ContentPack",description="Internal name used by your app. "
+    appid: APPID_TYPE = Field(default="ContentPack",description="Internal name used by your app. "
                                                                     "It may ONLY have characters, numbers, and underscores. No other characters are allowed.")
     version: str = Field(default="0.0.1",description="The version of your Content Pack.  This must follow semantic versioning guidelines.", validate_default=True)
 

--- a/contentctl/objects/detection_tags.py
+++ b/contentctl/objects/detection_tags.py
@@ -33,7 +33,7 @@ from contentctl.objects.enums import (
     SecurityContentProductName
 )
 from contentctl.objects.atomic import AtomicTest
-
+from contentctl.objects.annotated_types import MITRE_ATTACK_ID_TYPE, CVE_TYPE
 
 # TODO (#266): disable the use_enum_values configuration
 class DetectionTags(BaseModel):
@@ -50,7 +50,7 @@ class DetectionTags(BaseModel):
     def risk_score(self) -> int:
         return round((self.confidence * self.impact)/100)
 
-    mitre_attack_id: List[Annotated[str, Field(pattern=r"^T\d{4}(.\d{3})?$")]] = []
+    mitre_attack_id: List[MITRE_ATTACK_ID_TYPE] = []
     nist: list[NistCategory] = []
     observable: List[Observable] = []
     message: str = Field(...)
@@ -69,7 +69,7 @@ class DetectionTags(BaseModel):
         else:
             return RiskSeverity('low')
 
-    cve: List[Annotated[str, r"^CVE-[1|2]\d{3}-\d+$"]] = []
+    cve: List[CVE_TYPE] = []
     atomic_guid: List[AtomicTest] = []
     drilldown_search: Optional[str] = None
 

--- a/contentctl/objects/mitre_attack_enrichment.py
+++ b/contentctl/objects/mitre_attack_enrichment.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field, ConfigDict, HttpUrl, field_validator
 from typing import List, Annotated
 from enum import StrEnum
 import datetime
+from contentctl.objects.annotated_types import MITRE_ATTACK_ID_TYPE
 
 class MitreTactics(StrEnum):
     RECONNAISSANCE = "Reconnaissance"
@@ -85,7 +86,7 @@ class MitreAttackGroup(BaseModel):
 # TODO (#266): disable the use_enum_values configuration
 class MitreAttackEnrichment(BaseModel):
     ConfigDict(use_enum_values=True)
-    mitre_attack_id: Annotated[str, Field(pattern=r"^T\d{4}(.\d{3})?$")] = Field(...)
+    mitre_attack_id: MITRE_ATTACK_ID_TYPE = Field(...)
     mitre_attack_technique: str = Field(...)
     mitre_attack_tactics: List[MitreTactics] = Field(...)
     mitre_attack_groups: List[str] = Field(...)

--- a/contentctl/objects/story_tags.py
+++ b/contentctl/objects/story_tags.py
@@ -6,7 +6,7 @@ from enum import Enum
 
 from contentctl.objects.mitre_attack_enrichment import MitreAttackEnrichment
 from contentctl.objects.enums import StoryCategory, DataModel, KillChainPhase, SecurityContentProductName
-
+from contentctl.objects.annotated_types import CVE_TYPE,MITRE_ATTACK_ID_TYPE
 
 class StoryUseCase(str,Enum):
    FRAUD_DETECTION = "Fraud Detection"
@@ -27,10 +27,10 @@ class StoryTags(BaseModel):
 
    # enrichment
    mitre_attack_enrichments: Optional[List[MitreAttackEnrichment]] = None
-   mitre_attack_tactics: Optional[Set[Annotated[str, Field(pattern=r"^T\d{4}(.\d{3})?$")]]] = None
+   mitre_attack_tactics: Optional[Set[MITRE_ATTACK_ID_TYPE]] = None
    datamodels: Optional[Set[DataModel]] = None
    kill_chain_phases: Optional[Set[KillChainPhase]] = None
-   cve: List[Annotated[str, r"^CVE-[1|2]\d{3}-\d+$"]] = []
+   cve: List[CVE_TYPE] = []
    group: List[str] = Field([], description="A list of groups who leverage the techniques list in this Analytic Story.")
 
    def getCategory_conf(self) -> str:


### PR DESCRIPTION
Add annotated type definitions for commonly used Annotated Strings. This avoid redefining them in multiple places.
It also ensures that if we need to make an update, it only happens in one place.

The MITRE CVE Type annotations were wrong in a number of places - because they were not defined correctly, (notable, they were missing the `Field()` around the pattern) they were not working. For example:
`id: Annotated[str, r"^CVE-[1|2]\d{3}-\d+$"]` is WRONG and should be 
`id: Annotated[str, Field(pattern=r"^CVE-[1|2]\d{3}-\d+$")]` if used directly
