### PR TITLE
Option to not fail on missing detection during metadata check

### DIFF
--- a/contentctl/actions/inspect.py
+++ b/contentctl/actions/inspect.py
@@ -297,10 +297,10 @@ class Inspect:
             validation_errors[rule_name] = []
             # No detections should be removed from build to build
             if rule_name not in current_build_conf.detection_stanzas:
-                if config.exception_on_removed_detections:
-                    validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
-                else:
+                if config.supress_missing_content_exceptions:
                     print(f"[SUPPRESSED] {DetectionMissingError(rule_name=rule_name).long_message}")
+                else:
+                    validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
                 continue
             # Pull out the individual stanza for readability
             previous_stanza = previous_build_conf.detection_stanzas[rule_name]

--- a/contentctl/actions/inspect.py
+++ b/contentctl/actions/inspect.py
@@ -297,9 +297,11 @@ class Inspect:
             validation_errors[rule_name] = []
             # No detections should be removed from build to build
             if rule_name not in current_build_conf.detection_stanzas:
-                validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
+                if config.exception_on_removed_detections:
+                    validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
+                else:
+                    print(f"[SUPPRESSED] {DetectionMissingError(rule_name=rule_name).long_message}")
                 continue
-
             # Pull out the individual stanza for readability
             previous_stanza = previous_build_conf.detection_stanzas[rule_name]
             current_stanza = current_build_conf.detection_stanzas[rule_name]
@@ -335,7 +337,7 @@ class Inspect:
                 )
 
         # Convert our dict mapping to a flat list of errors for use in reporting
-        validation_error_list = [x for inner_list in validation_errors.values() for x in inner_list]
+        validation_error_list = [x for inner_list in validation_errors.values() for x in inner_list]    
 
         # Report failure/success
         print("\nDetection Metadata Validation:")

--- a/contentctl/contentctl.py
+++ b/contentctl/contentctl.py
@@ -81,8 +81,8 @@ def build_func(config:build)->DirectorOutputDto:
 
 def inspect_func(config:inspect)->str:
     #Make sure that we have built the most recent version of the app
-    _ = build_func(config)
-    inspect_token = Inspect().execute(config)
+    director = build_func(config)
+    inspect_token = Inspect().execute(config, director)
     return inspect_token
     
 

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Union, Optional, List, Any, Annotated
+from typing import TYPE_CHECKING, Union, Optional, List, Any, Annotated, Self
 import re
 import pathlib
 from enum import Enum
@@ -881,6 +881,27 @@ class Detection_Abstract(SecurityContentObject):
 
         # If all tests are successful (PASS/SKIP), return True
         return True
+
+    @classmethod
+    def get_detection_object_from_stanza_name(cls, stanza_name: str, app:CustomApp, detections: list[Self]) -> Self:
+        """Just as we have a way to go from detection to conf stanza, provide a mapping to go from conf stanza to detection.
+
+        Args:
+            stanza_name (str): The stanza name, probably read from savedsearches.conf
+            app (CustomApp): The app that was used to build the conf file.
+            detections (list[Detection_Abstract]): List of all detections in this repo
+
+        Raises:
+            Exception: An exception will be raised if the expected detection is not found
+
+        Returns:
+            Detection_Abstract: return the Detection_Abtract object with the appropriate name
+        """        
+        matching_detections = list(filter(lambda d: d.get_conf_stanza_name(app) == stanza_name, detections))
+        if len(matching_detections) == 1:
+            return matching_detections[0]
+        raise Exception(f"Failed to find exactly one detection with the conf stanza '{stanza_name}'")
+        
 
     def get_summary(
         self,

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -308,12 +308,14 @@ class inspect(build):
             "should be enabled."
         )
     )
-    exception_on_removed_detections: bool = Field(
-        default=True,
+    supress_missing_content_exceptions: bool = Field(
+        default=False,
         description=(
-            "Throw an exception during metadata validation if a detection that existed in "
+            "Suppress exceptions during metadata validation if a detection that existed in "
             "the previous build does not exist in this build. This is to ensure that content "
-            "is not accidentally removed."
+            "is not accidentally removed. In order to support testing both public and private "
+            "content, this warning can be suppressed. If it is suppressed, it will still be "
+            "printed out as a warning."
         )
     )
     enrichments: bool = Field(

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -159,8 +159,6 @@ class CustomApp(App_Base):
                                 verbose_print=True)
         return str(destination)
     
-
-
 # TODO (#266): disable the use_enum_values configuration
 class Config_Base(BaseModel):
     model_config = ConfigDict(use_enum_values=True,validate_default=True, arbitrary_types_allowed=True)
@@ -288,7 +286,6 @@ class build(validate):
 
     def getAppTemplatePath(self)->pathlib.Path:
         return self.path/"app_template"
-    
 
 
 class StackType(StrEnum):
@@ -309,6 +306,14 @@ class inspect(build):
         description=(
             "Flag indicating whether detection metadata validation and versioning enforcement "
             "should be enabled."
+        )
+    )
+    exception_on_removed_detections: bool = Field(
+        default=True,
+        description=(
+            "Throw an exception during metadata validation if a detection that existed in "
+            "the previous build does not exist in this build. This is to ensure that content "
+            "is not accidentally removed."
         )
     )
     enrichments: bool = Field(
@@ -952,7 +957,6 @@ class test_servers(test_common):
                 index+=1
 
 
-        
 class release_notes(Config_Base):
     old_tag:Optional[str] = Field(None, description="Name of the tag to diff against to find new content. "
                                           "If it is not supplied, then it will be inferred as the "
@@ -1035,5 +1039,3 @@ class release_notes(Config_Base):
         
         
     #     return self
-
-

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -308,7 +308,7 @@ class inspect(build):
             "should be enabled."
         )
     )
-    supress_missing_content_exceptions: bool = Field(
+    suppress_missing_content_exceptions: bool = Field(
         default=False,
         description=(
             "Suppress exceptions during metadata validation if a detection that existed in "
@@ -335,6 +335,13 @@ class inspect(build):
         )
     )
     stack_type: StackType = Field(description="The type of your Splunk Cloud Stack")
+
+    @property
+    def metadata_results_file(self) -> pathlib.Path:
+        
+        return self.getPackageFilePath().parent / (self.getPackageFilePath().name + ".metadata-validation-results.yml")
+        
+        
 
     @field_validator("enrichments", mode="after")
     @classmethod

--- a/contentctl/objects/errors.py
+++ b/contentctl/objects/errors.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
+from pydantic import BaseModel, ConfigDict
+from pydantic.dataclasses import dataclass
 from uuid import UUID
-
+from typing import Self, Sequence
+from contentctl.output.yml_writer import YmlWriter
+import pathlib
+from contentctl.objects.constants import CONTENTCTL_MAX_STANZA_LENGTH
 
 class ValidationFailed(Exception):
     """Indicates not an error in execution, but a validation failure"""
@@ -27,7 +33,33 @@ class MetadataValidationError(Exception, ABC):
     Base class for any errors arising from savedsearches.conf detection metadata validation
     """
     # The name of the rule the error relates to
+    # rule_name must be set in the _init_ functions of
+    # individual exceptions, rather than here, because
+    # it is used to calculate the long_message and 
+    # short_message properties.
     rule_name: str
+
+    # Determine whether or not this Exception 
+    # should actually be treated as a WARNING 
+    # rather than an Exception. This allows
+    # individual Exceptions to be enabled or 
+    # disabled based on command line flags
+    suppress_as_warning: bool
+
+    file_path: pathlib.Path
+
+    def __init__(
+            self,
+            file_path: pathlib.Path,
+            rule_name: str,
+            suppress_as_warning: bool = False,
+            *args: object
+    ) -> None:
+        print(f"file path in MVE: {file_path}")
+        self.file_path = file_path,
+        self.rule_name = rule_name
+        self.suppress_as_warning = suppress_as_warning
+        super().__init__(self.long_message, *args)
 
     @property
     @abstractmethod
@@ -46,6 +78,28 @@ class MetadataValidationError(Exception, ABC):
         :returns: a str, the message
         """
         raise NotImplementedError()
+    
+    @staticmethod
+    @abstractmethod
+    def error_plain_name() -> str:
+        """
+        A plain, English language name for the error
+        :returns: a str, the message
+        """
+        raise NotImplementedError()
+    
+    def toJSON(self) -> dict[str, str | bool | UUID | int]:
+        return {"rule_name": self.rule_name,
+                "suppress_as_warning": self.suppress_as_warning,
+                "short_message": self.short_message,
+                "long_message": self.long_message,
+                "file_path": str(self.file_path)}
+    
+
+    @classmethod
+    def sort_and_filter(cls, errors: list[MetadataValidationError]) -> list[Self]:
+        x = list(filter(lambda error: isinstance(error, cls), errors))
+        return sorted(x, key = lambda e: (e.rule_name, e.suppress_as_warning))
 
 
 class DetectionMissingError(MetadataValidationError):
@@ -55,10 +109,11 @@ class DetectionMissingError(MetadataValidationError):
     def __init__(
             self,
             rule_name: str,
+            suppress_as_warning: bool = False,
             *args: object
     ) -> None:
         self.rule_name = rule_name
-        super().__init__(self.long_message, *args)
+        super().__init__(pathlib.Path("missing"), self.rule_name, suppress_as_warning, self.long_message, *args)
 
     @property
     def long_message(self) -> str:
@@ -67,7 +122,7 @@ class DetectionMissingError(MetadataValidationError):
         :returns: a str, the message
         """
         return (
-            f"Rule '{self.rule_name}' in previous build not found in current build; "
+            f"'{self.rule_name}' in previous build not found in current build; "
             "detection may have been removed or renamed."
         )
 
@@ -78,8 +133,18 @@ class DetectionMissingError(MetadataValidationError):
         :returns: a str, the message
         """
         return (
-            "Detection from previous build not found in current build."
+            f"{self.rule_name.ljust(CONTENTCTL_MAX_STANZA_LENGTH)} from previous build not found in current build."
         )
+
+    @staticmethod
+    def error_plain_name() -> str:
+        """
+        A plain, English language name for the error
+        :returns: a str, the message
+        """
+        return "Detection Missing Error"
+    
+    
 
 
 class DetectionIDError(MetadataValidationError):
@@ -94,15 +159,18 @@ class DetectionIDError(MetadataValidationError):
 
     def __init__(
             self,
+            file_path:pathlib.Path,
             rule_name: str,
             current_id: UUID,
             previous_id: UUID,
+            suppress_as_warning: bool = False,
             *args: object
     ) -> None:
+        print(f"file path in DIDE: {file_path}")
         self.rule_name = rule_name
         self.current_id = current_id
         self.previous_id = previous_id
-        super().__init__(self.long_message, *args)
+        super().__init__(file_path, self.rule_name, suppress_as_warning, self.long_message, *args)
 
     @property
     def long_message(self) -> str:
@@ -123,9 +191,20 @@ class DetectionIDError(MetadataValidationError):
         :returns: a str, the message
         """
         return (
-            f"Detection ID {self.current_id} in current build does not match ID {self.previous_id} in previous build."
+            f"{self.rule_name.ljust(CONTENTCTL_MAX_STANZA_LENGTH)} with id {self.current_id} in current build does not match ID {self.previous_id} in previous build."
         )
+    
+    @staticmethod
+    def error_plain_name() -> str:
+        """
+        A plain, English language name for the error
+        :returns: a str, the message
+        """
+        return "Detection ID Error"
 
+    def toJSON(self) -> dict[str, str | bool | UUID | int]:
+        return super().toJSON() | {"current_id": self.current_id, 
+                                   "previous_id": self.previous_id}
 
 class VersioningError(MetadataValidationError, ABC):
     """
@@ -139,15 +218,22 @@ class VersioningError(MetadataValidationError, ABC):
 
     def __init__(
             self,
+            file_path:pathlib.Path,
             rule_name: str,
             current_version: int,
             previous_version: int,
+            suppress_as_warning: bool = False,
             *args: object
     ) -> None:
+        print(f"file path in VE: {file_path}")
         self.rule_name = rule_name
         self.current_version = current_version
         self.previous_version = previous_version
-        super().__init__(self.long_message, *args)
+        super().__init__(file_path, self.rule_name, suppress_as_warning, self.long_message, *args)
+
+    def toJSON(self) -> dict[str, str | bool | UUID | int]:
+        return super().toJSON() | {"current_version": self.current_version, 
+                                   "previous_version": self.previous_version}
 
 
 class VersionDecrementedError(VersioningError):
@@ -173,15 +259,37 @@ class VersionDecrementedError(VersioningError):
         :returns: a str, the message
         """
         return (
-            f"Detection version ({self.current_version}) in current build is less than version "
+            f"{self.rule_name.ljust(CONTENTCTL_MAX_STANZA_LENGTH)} with version ({self.current_version}) in current build is less than version "
             f"({self.previous_version}) in previous build."
         )
 
+    @staticmethod
+    def error_plain_name() -> str:
+        """
+        A plain, English language name for the error
+        :returns: a str, the message
+        """
+        return "Versioning Error"
 
+    
 class VersionBumpingError(VersioningError):
     """
     An error indicating the detection changed but its version wasn't bumped appropriately
     """
+
+    @property
+    def bumped_version(self) -> int:
+        """
+        Returns the verion that we should bump to.
+        By default, we should bump one version above
+        the previous_version. However, it is not considered
+        an ERROR to bump more than 1 if done in the YML.
+
+        Returns:
+            int: previous_version + 1
+        """
+        return self.previous_version + 1
+
     @property
     def long_message(self) -> str:
         """
@@ -191,7 +299,7 @@ class VersionBumpingError(VersioningError):
         return (
             f"Rule '{self.rule_name}' has changed in current build compared to previous "
             "build (stanza hashes differ); the detection version should be bumped "
-            f"to at least {self.previous_version + 1}."
+            f"to at least {self.bumped_version}."
         )
 
     @property
@@ -201,5 +309,91 @@ class VersionBumpingError(VersioningError):
         :returns: a str, the message
         """
         return (
-            f"Detection version in current build should be bumped to at least {self.previous_version + 1}."
+            f"{self.rule_name.ljust(CONTENTCTL_MAX_STANZA_LENGTH)} version  must be bumped to at least {self.bumped_version}."
         )
+    
+    @staticmethod
+    def error_plain_name() -> str:
+        """
+        A plain, English language name for the error
+        :returns: a str, the message
+        """
+        return "Version Bumping Error"
+
+    def toJSON(self) -> dict[str, str | bool | UUID | int]:
+        return super().toJSON() | {"current_version": self.current_version, 
+                                   "previous_version": self.previous_version, 
+                                   "bumped_version": self.bumped_version}
+
+class MetadataValidationErrorFile(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    detectionMissingErrors:list[DetectionMissingError] = []
+    detectionIdErrors: list[DetectionIDError] = []
+    versionDecrementedErrors: list[VersionDecrementedError] = []
+    versionBumpingErrors: list[VersionBumpingError] = []
+
+    @classmethod
+    def parse_from_errors_list(cls, errors: list[MetadataValidationError]) -> Self:
+        return cls(
+            detectionMissingErrors=DetectionMissingError.sort_and_filter(errors),
+            detectionIdErrors=DetectionIDError.sort_and_filter(errors),
+            versionDecrementedErrors=VersionDecrementedError.sort_and_filter(errors),
+            versionBumpingErrors=VersionBumpingError.sort_and_filter(errors),
+        )
+    
+    def add_exception(self, exception:MetadataValidationError):
+        if isinstance(exception, DetectionMissingError):
+            self.detectionMissingErrors.append(exception)
+        elif isinstance(exception, DetectionIDError):
+            self.detectionIdErrors.append(exception)
+        elif isinstance(exception, VersionDecrementedError):
+            self.versionDecrementedErrors.append(exception)
+        elif isinstance(exception, VersionBumpingError):
+            self.versionBumpingErrors.append(exception)
+        else:
+            raise Exception("Unknown error type when generating "
+                            f"Metadata Validation Error File - {type(exception)}")
+    
+    
+
+    def cli_format_section(self, errors: Sequence[MetadataValidationError], section_name:str) -> str:
+        """
+        A header to print the the command line
+        :returns: a str, the message
+        """
+        is_suppressed = True if True in [e.suppress_as_warning for e in errors] else False
+
+        if is_suppressed:
+            return f"{section_name} - {len(errors)} Suppressed Errors"
+    
+        header = f"{section_name} - {len(errors)} Errors"
+        body = '\n  ❌'.join([""]+[error.short_message for error in errors])
+        return f"{header}{body}"
+
+    def print_errors(self):
+        non_suppressed_errors = list(filter(lambda e: not e.suppress_as_warning, 
+                                            self.detectionMissingErrors + 
+                                            self.detectionIdErrors + 
+                                            self.versionDecrementedErrors + 
+                                            self.versionBumpingErrors))
+        if len(non_suppressed_errors) == 0:
+            print("\t✅ Detection metadata looks good and all versions were bumped appropriately :)")
+        else:
+            print(self.cli_format_section(self.detectionMissingErrors, DetectionMissingError.error_plain_name()))
+            print(self.cli_format_section(self.detectionIdErrors, str(DetectionIDError.error_plain_name())))
+            print(self.cli_format_section(self.versionDecrementedErrors, str(VersionDecrementedError.error_plain_name())))
+            print(self.cli_format_section(self.versionBumpingErrors, str(VersionBumpingError.error_plain_name())))
+        
+                
+            
+
+    def write_to_file(self, output_file:pathlib.Path):
+        output_dict:dict[str,list[dict[str, str | bool | UUID | int]]] = {}
+        output_dict['detectionMissingErrors'] = [e.toJSON() for e in self.detectionMissingErrors]
+        output_dict['detectionIdErrors'] = [e.toJSON() for e in self.detectionIdErrors]
+        output_dict['versionDecrementedErrors'] = [e.toJSON() for e in self.versionDecrementedErrors]
+        output_dict['versionBumpingErrors'] = [e.toJSON() for e in self.versionBumpingErrors]
+        YmlWriter.writeYmlFile(str(output_file), output_dict)
+    
+            


### PR DESCRIPTION
add new option to contentctl inspect that makes missing detections NTT an error - instead just print a warning message.