### PR TITLE
Testing on Datasource changes

### DIFF
--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -647,6 +647,7 @@ class Detection_Abstract(SecurityContentObject):
         objects: list[SecurityContentObject] = []
         objects += self.macros
         objects += self.lookups
+        objects += self.data_source_objects
         return objects
 
     @field_validator("deployment", mode="before")


### PR DESCRIPTION
When we calculate changes between two branches in order to run tests, we currently do not catch data source object changes as content dependencies. Following the same path in which we calculate macros and lookups as being content dependencies, this PR will attempt to change the diff calculation to include data source object changes. 

Notably, this will then trigger the testing for each of these detections when we have an "Auto Update TA" PR like so: https://github.com/splunk/security_content/pull/3154

This testing will provide the confidence and verification that such changes can be merged without issues.