### PR TITLE
Optionally suppress missing detections during metadata validation

### DIFF
--- a/contentctl/actions/inspect.py
+++ b/contentctl/actions/inspect.py
@@ -297,9 +297,11 @@ class Inspect:
             validation_errors[rule_name] = []
             # No detections should be removed from build to build
             if rule_name not in current_build_conf.detection_stanzas:
-                validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
+                if config.suppress_missing_content_exceptions:
+                    print(f"[SUPPRESSED] {DetectionMissingError(rule_name=rule_name).long_message}")
+                else:
+                    validation_errors[rule_name].append(DetectionMissingError(rule_name=rule_name))
                 continue
-
             # Pull out the individual stanza for readability
             previous_stanza = previous_build_conf.detection_stanzas[rule_name]
             current_stanza = current_build_conf.detection_stanzas[rule_name]
@@ -335,7 +337,7 @@ class Inspect:
                 )
 
         # Convert our dict mapping to a flat list of errors for use in reporting
-        validation_error_list = [x for inner_list in validation_errors.values() for x in inner_list]
+        validation_error_list = [x for inner_list in validation_errors.values() for x in inner_list]    
 
         # Report failure/success
         print("\nDetection Metadata Validation:")

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -159,8 +159,6 @@ class CustomApp(App_Base):
                                 verbose_print=True)
         return str(destination)
     
-
-
 # TODO (#266): disable the use_enum_values configuration
 class Config_Base(BaseModel):
     model_config = ConfigDict(use_enum_values=True,validate_default=True, arbitrary_types_allowed=True)
@@ -288,7 +286,6 @@ class build(validate):
 
     def getAppTemplatePath(self)->pathlib.Path:
         return self.path/"app_template"
-    
 
 
 class StackType(StrEnum):
@@ -309,6 +306,16 @@ class inspect(build):
         description=(
             "Flag indicating whether detection metadata validation and versioning enforcement "
             "should be enabled."
+        )
+    )
+    suppress_missing_content_exceptions: bool = Field(
+        default=False,
+        description=(
+            "Suppress exceptions during metadata validation if a detection that existed in "
+            "the previous build does not exist in this build. This is to ensure that content "
+            "is not accidentally removed. In order to support testing both public and private "
+            "content, this warning can be suppressed. If it is suppressed, it will still be "
+            "printed out as a warning."
         )
     )
     enrichments: bool = Field(
@@ -952,7 +959,6 @@ class test_servers(test_common):
                 index+=1
 
 
-        
 class release_notes(Config_Base):
     old_tag:Optional[str] = Field(None, description="Name of the tag to diff against to find new content. "
                                           "If it is not supplied, then it will be inferred as the "
@@ -1035,5 +1041,3 @@ class release_notes(Config_Base):
         
         
     #     return self
-
-


### PR DESCRIPTION

Using the flag --suppress-missing-content-exceptions during metadata validation will allow validation to succeed even if content has been removed. This is important to support both the removal of content, if this removal is intentional, and content that may be stored in a different repo that has not yet been combined with the content in the current repo.