### PR TITLE
All more custom indexes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.4.0"
+version = "4.5.0"
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
This PR contains changes from the following PR contributed by community member @ax-hsmith.

The additional change we will make here is that the get_all_indexes function will also include the standard contentctl replay index.

We will also consider comment https://github.com/splunk/contentctl/pull/307#issuecomment-2413877026 for additional changes.