### PR TITLE
add --compare_against flag to release_notes action

### DIFF
--- a/contentctl/actions/release_notes.py
+++ b/contentctl/actions/release_notes.py
@@ -116,9 +116,8 @@ class ReleaseNotes:
                 raise ValueError(f"latest branch {config.latest_branch} does not exist in the repository. Make sure your branch name is correct")
             if config.compare_against not in repo.branches:
                 raise ValueError(f"compare_against branch {config.compare_against} does not exist in the repository. Make sure your branch name is correct")
-            compare_against = config.compare_against
             commit1 = repo.commit(config.latest_branch)
-            commit2 = repo.commit(compare_against)    
+            commit2 = repo.commit(config.compare_against)    
             diff_index = commit2.diff(commit1)
         
         modified_files:List[pathlib.Path] = []

--- a/contentctl/actions/release_notes.py
+++ b/contentctl/actions/release_notes.py
@@ -116,7 +116,7 @@ class ReleaseNotes:
                 raise ValueError(f"latest branch {config.latest_branch} does not exist in the repository. Make sure your branch name is correct")
             if config.compare_against not in repo.branches:
                 raise ValueError(f"compare_against branch {config.compare_against} does not exist in the repository. Make sure your branch name is correct")
-                compare_against = config.compare_against
+            compare_against = config.compare_against
             commit1 = repo.commit(config.latest_branch)
             commit2 = repo.commit(compare_against)    
             diff_index = commit2.diff(commit1)

--- a/contentctl/actions/release_notes.py
+++ b/contentctl/actions/release_notes.py
@@ -114,7 +114,10 @@ class ReleaseNotes:
             #If a branch name is supplied, compare against develop
             if config.latest_branch not in repo.branches:
                 raise ValueError(f"latest branch {config.latest_branch} does not exist in the repository. Make sure your branch name is correct")
-            compare_against = "develop"
+            if config.compare_against not in repo.branches:
+                compare_against = config.compare_against
+            else:
+                compare_against = "develop"
             commit1 = repo.commit(config.latest_branch)
             commit2 = repo.commit(compare_against)    
             diff_index = commit2.diff(commit1)

--- a/contentctl/actions/release_notes.py
+++ b/contentctl/actions/release_notes.py
@@ -115,9 +115,8 @@ class ReleaseNotes:
             if config.latest_branch not in repo.branches:
                 raise ValueError(f"latest branch {config.latest_branch} does not exist in the repository. Make sure your branch name is correct")
             if config.compare_against not in repo.branches:
+                raise ValueError(f"compare_against branch {config.compare_against} does not exist in the repository. Make sure your branch name is correct")
                 compare_against = config.compare_against
-            else:
-                compare_against = "develop"
             commit1 = repo.commit(config.latest_branch)
             commit2 = repo.commit(compare_against)    
             diff_index = commit2.diff(commit1)

--- a/contentctl/actions/release_notes.py
+++ b/contentctl/actions/release_notes.py
@@ -116,6 +116,7 @@ class ReleaseNotes:
                 raise ValueError(f"latest branch {config.latest_branch} does not exist in the repository. Make sure your branch name is correct")
             if config.compare_against not in repo.branches:
                 raise ValueError(f"compare_against branch {config.compare_against} does not exist in the repository. Make sure your branch name is correct")
+            
             commit1 = repo.commit(config.latest_branch)
             commit2 = repo.commit(config.compare_against)    
             diff_index = commit2.diff(commit1)
@@ -190,7 +191,7 @@ class ReleaseNotes:
 
         if config.latest_branch:
             print(f"Generating release notes       - \033[92m{config.latest_branch}\033[0m")
-            print(f"Compared against               - \033[92m{compare_against}\033[0m")
+            print(f"Compared against               - \033[92m{config.compare_against}\033[0m")
             print("\n## Release notes for ESCU " + config.latest_branch)
 
         notes = [self.create_notes(config.path, stories_added, header="New Analytic Story"),

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -966,8 +966,7 @@ class release_notes(Config_Base):
     new_tag:Optional[str] = Field(None, description="Name of the tag containing new content. If it is not supplied,"
                                           " then it will be inferred as the newest tag at runtime.")
     latest_branch:Optional[str] = Field(None, description="Branch for which we are generating release notes")
-    compare_against:Optional[str] = Field(None, description="Branch for which we are generating release notes against")
-    
+    compare_against: str = Field(default="develop", description="Branch for which we are generating release notes against")
     def releaseNotesFilename(self, filename:str)->pathlib.Path:
         #Assume that notes are written to dist/. This does not respect build_dir since that is
         #only a member of build

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -966,7 +966,7 @@ class release_notes(Config_Base):
     new_tag:Optional[str] = Field(None, description="Name of the tag containing new content. If it is not supplied,"
                                           " then it will be inferred as the newest tag at runtime.")
     latest_branch:Optional[str] = Field(None, description="Branch name for which we are generating release notes for")
-    compare_against:Optional[str] = Field(None, description="Branch name for which we are comparing the files changes against")
+    compare_against:Optional[str] = Field(default="develop", description="Branch name for which we are comparing the files changes against")
 
     def releaseNotesFilename(self, filename:str)->pathlib.Path:
         #Assume that notes are written to dist/. This does not respect build_dir since that is

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -966,6 +966,7 @@ class release_notes(Config_Base):
     new_tag:Optional[str] = Field(None, description="Name of the tag containing new content. If it is not supplied,"
                                           " then it will be inferred as the newest tag at runtime.")
     latest_branch:Optional[str] = Field(None, description="Branch for which we are generating release notes")
+    compare_against:Optional[str] = Field(None, description="Branch for which we are generating release notes against")
     
     def releaseNotesFilename(self, filename:str)->pathlib.Path:
         #Assume that notes are written to dist/. This does not respect build_dir since that is

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -965,8 +965,9 @@ class release_notes(Config_Base):
                                           "second newest tag at runtime.")
     new_tag:Optional[str] = Field(None, description="Name of the tag containing new content. If it is not supplied,"
                                           " then it will be inferred as the newest tag at runtime.")
-    latest_branch:Optional[str] = Field(None, description="Branch for which we are generating release notes")
-    compare_against: str = Field(default="develop", description="Branch for which we are generating release notes against")
+    latest_branch:Optional[str] = Field(None, description="Branch name for which we are generating release notes for")
+    compare_against:Optional[str] = Field(None, description="Branch name for which we are comparing the files changes against")
+
     def releaseNotesFilename(self, filename:str)->pathlib.Path:
         #Assume that notes are written to dist/. This does not respect build_dir since that is
         #only a member of build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.4.0"
+version = "4.4.1"
+
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
 license = "Apache 2.0"


### PR DESCRIPTION
adds a flag to release_notes action  `-- compare_against` : so that we can mention another branch name to compare and create notes against. Tested locally and the generation of notes looked good!