### PR TITLE
remove "cloud" from the security_domain enum

### DIFF
--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -264,7 +264,7 @@ class CorrelationSearch(BaseModel):
         :returns: the search path
         :rtype: str
         """
-        return f"/saved/searches/{self.name}"
+        return f"saved/searches/{self.name}"
 
     @computed_field
     @cached_property

--- a/contentctl/objects/enums.py
+++ b/contentctl/objects/enums.py
@@ -330,7 +330,6 @@ class SecurityDomain(str, enum.Enum):
     IDENTITY = "identity"
     ACCESS = "access"
     AUDIT = "audit"
-    CLOUD = "cloud"
 
 class AssetType(str, enum.Enum):
     AWS_ACCOUNT = "AWS Account"


### PR DESCRIPTION
"cloud" was erroneously included as one of the possible security_domains which are used by enterprise security.
See the following message, which shows 8 pieces of content failing after this update.

A PR has been created in security_content with fixes to the relevant detections as well: https://github.com/splunk/security_content/pull/3172

<img width="1260" alt="image" src="https://github.com/user-attachments/assets/a933994c-1af7-4aaa-bf9a-ea0b982971c9">
