### PR TITLE
Fix savedsearches path issue

### DIFF
--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -988,6 +988,9 @@ class CorrelationSearch(BaseModel):
         and the cron schedule persist after cleanup
         :param delete_test_index: flag indicating whether the test index should be cleared or not (defaults to False)
         """
+        print("\n\n\n\npre cleanup\n\n\n\n")
+        _ = input()
+        print("\n\n\n\ngot user okay\n\n\n\n")
         # delete_test_index can't be true when test_index is None
         if delete_test_index and (self.test_index is None):
             raise ClientError("test_index is None, cannot delete it")

--- a/contentctl/objects/correlation_search.py
+++ b/contentctl/objects/correlation_search.py
@@ -264,7 +264,7 @@ class CorrelationSearch(BaseModel):
         :returns: the search path
         :rtype: str
         """
-        return f"/saved/searches/{self.name}"
+        return f"saved/searches/{self.name}"
 
     @computed_field
     @cached_property
@@ -988,9 +988,6 @@ class CorrelationSearch(BaseModel):
         and the cron schedule persist after cleanup
         :param delete_test_index: flag indicating whether the test index should be cleared or not (defaults to False)
         """
-        print("\n\n\n\npre cleanup\n\n\n\n")
-        _ = input()
-        print("\n\n\n\ngot user okay\n\n\n\n")
         # delete_test_index can't be true when test_index is None
         if delete_test_index and (self.test_index is None):
             raise ClientError("test_index is None, cannot delete it")


### PR DESCRIPTION
Fix path for saved search for scheduling to run during integration testing. 
This bad path causes every integration test to fail.

When reviewing this PR, please ensure that you use --enable-integration-testing with Enterprise Security installed.
Otherwise, the original bug, or fix, will not be apparent.