### PR TITLE
Fix a bug where App_Base.getSplunkbasePath() was broken and did not w…

### DIFF
--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -47,7 +47,7 @@ class App_Base(BaseModel,ABC):
     
 
     def getSplunkbasePath(self)->HttpUrl:
-        return HttpUrl(SPLUNKBASE_URL.format(uid=self.uid, release=self.version))
+        return HttpUrl(SPLUNKBASE_URL.format(uid=self.uid, version=self.version))
 
     @abstractmethod
     def getApp(self, config:test, stage_file:bool=False)->str:


### PR DESCRIPTION
Fix a bug where `App_Base.getSplunkbasePath()` was broken and did not work at all. Fixes #295.