### PR TITLE
Fix a bug where the jinja template for `analyticsories_detection` cra…

### DIFF
--- a/contentctl/output/templates/analyticstories_detections.j2
+++ b/contentctl/output/templates/analyticstories_detections.j2
@@ -5,7 +5,7 @@
 {% if (detection.type == 'TTP' or detection.type == 'Anomaly' or detection.type == 'Hunting' or detection.type == 'Correlation') %}
 [savedsearch://{{ detection.get_conf_stanza_name(app) }}]
 type = detection
-asset_type = {{ detection.tags.asset_type.value }}
+asset_type = {{ detection.tags.asset_type }}
 confidence = medium
 explanation = {{ (detection.explanation if detection.explanation else detection.description) | escapeNewlines() }}
 {% if detection.how_to_implement is defined %}


### PR DESCRIPTION
Fix a bug where the jinja template for `analyticsories_detection` crashed when specifying a `detection.tags.asset_type`. Fixes #313.