### PR TITLE
don't declare py3.13 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.4.5"
+version = "4.4.6"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 contentctl = 'contentctl.contentctl:main'
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.11,<3.13"
 pydantic = "^2.8.2"
 PyYAML = "^6.0.2"
 requests = "~2.32.3"


### PR DESCRIPTION
Adjust pyproject.toml - until #302 lands, which is going to require a bit more work now, we should ensure we don't list python3.13 as compatible- since its not.