### PR TITLE
Pin Pydantic to Resolve Contentctl Bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "contentctl"
-version = "4.4.6"
+version = "4.4.7"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
@@ -12,7 +12,7 @@ contentctl = 'contentctl.contentctl:main'
 
 [tool.poetry.dependencies]
 python = "^3.11,<3.13"
-pydantic = "^2.8.2"
+pydantic = "~2.9.2"
 PyYAML = "^6.0.2"
 requests = "~2.32.3"
 pycvesearch = "^1.2"


### PR DESCRIPTION
Pydantic 2.10 release causes an exception to be thrown in our codebaee. resolving the exception may take some time, so we pin it for now to a working version.