### PR TITLE
GH Actions Matrix update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 6
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/testEndToEnd.yml
+++ b/.github/workflows/testEndToEnd.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
-        operating_system: ["ubuntu-20.04", "ubuntu-24.04", "macos-15", "macos-14", "windows-2022"]
+        operating_system: ["ubuntu-24.04", "macos-15", "windows-2022"]
         #operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest"]
 
 

--- a/.github/workflows/test_against_escu.yml
+++ b/.github/workflows/test_against_escu.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         python_version: ["3.11", "3.12", "3.13"]
         
-        operating_system: ["ubuntu-20.04", "ubuntu-24.04", "macos-15", "macos-14"]
+        operating_system: ["ubuntu-24.04", "macos-15"]
         # Do not test against ESCU until known character encoding issue is resolved
         # operating_system: ["ubuntu-20.04", "ubuntu-22.04", "macos-latest", "macos-14", "windows-2022"]
 


### PR DESCRIPTION
Two simple changes here:
1. Added the GitHub Actions ecosystem to our dependabot config. This will give us PRs when there's new versions of actions, which helps avoid some of the "old runtime" warnings we've seen in our other repos.
2. Shrinks the test matrix for `testEndToEnd.yml` and `test_against_escu.yml`. With [this announcement](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/), the Ubuntu 20.04 runner image is being retired in April. This gets it off our plate entirely a bit sooner. I've also removed the second macos image from the matrices, for simplicity and to reduce total time waiting for otherwise-duplicate jobs to finish.