### PR TITLE
fix dashboard file names

### DIFF
--- a/contentctl/objects/constants.py
+++ b/contentctl/objects/constants.py
@@ -124,7 +124,6 @@ CONTENTCTL_DETECTION_STANZA_NAME_FORMAT_TEMPLATE = (
     "{app_label} - {detection_name} - Rule"
 )
 
-CONTENTCTL_DASHBOARD_LABEL_TEMPLATE = "{app_label} - {dashboard_name}"
 CONTENTCTL_BASELINE_STANZA_NAME_FORMAT_TEMPLATE = "{app_label} - {detection_name}"
 CONTENTCTL_RESPONSE_TASK_NAME_FORMAT_TEMPLATE = (
     "{app_label} - {detection_name} - Response Task"

--- a/contentctl/objects/dashboard.py
+++ b/contentctl/objects/dashboard.py
@@ -102,7 +102,7 @@ class Dashboard(SecurityContentObject):
             )
         # Prefix with the appLabel__ in order to make a search for these easy with match="__"
         # in the default.xml file
-        filename = f"{config.app.label}__{self.file_path.stem}".lower().replace(
+        filename = f"{config.app.label}__{self.file_path.stem}.xml".lower().replace(
             " ", "_"
         )
 

--- a/contentctl/objects/dashboard.py
+++ b/contentctl/objects/dashboard.py
@@ -7,11 +7,10 @@ from jinja2 import Environment
 from pydantic import Field, Json, model_validator
 
 from contentctl.objects.config import build
-from contentctl.objects.constants import CONTENTCTL_DASHBOARD_LABEL_TEMPLATE
 from contentctl.objects.security_content_object import SecurityContentObject
 
 DEFAULT_DASHBOARD_JINJA2_TEMPLATE = """<dashboard version="2" theme="{{ dashboard.theme }}">
-    <label>{{ dashboard.label(config) }}</label>
+    <label>{{ dashboard.name }}</label>
     <description></description>
     <definition><![CDATA[
 {{ dashboard.pretty_print_json_obj() }}
@@ -49,11 +48,6 @@ class Dashboard(SecurityContentObject):
     json_obj: Json[dict[str, Any]] = Field(
         ..., description="Valid JSON object that describes the dashboard"
     )
-
-    def label(self, config: build) -> str:
-        return CONTENTCTL_DASHBOARD_LABEL_TEMPLATE.format(
-            app_label=config.app.label, dashboard_name=self.name
-        )
 
     @model_validator(mode="before")
     @classmethod
@@ -102,13 +96,16 @@ class Dashboard(SecurityContentObject):
         return json.dumps(self.json_obj, indent=4)
 
     def getOutputFilepathRelativeToAppRoot(self, config: build) -> pathlib.Path:
-        # for clarity, the name of the dashboard file will follow the same convention
-        # as we use for detections, prefixing it with app_name -
         if self.file_path is None:
             raise FileNotFoundError(
                 f"Dashboard {self.name} file_path was None. Dashboards must be backed by a file."
             )
-        filename = f"{self.file_path.stem}.xml"
+        # Prefix with the appLabel__ in order to make a search for these easy with match="__"
+        # in the default.xml file
+        filename = f"{config.app.label}__{self.file_path.stem}".lower().replace(
+            " ", "_"
+        )
+
         return pathlib.Path("default/data/ui/views") / filename
 
     def writeDashboardFile(self, j2_env: Environment, config: build):

--- a/contentctl/objects/dashboard.py
+++ b/contentctl/objects/dashboard.py
@@ -104,7 +104,11 @@ class Dashboard(SecurityContentObject):
     def getOutputFilepathRelativeToAppRoot(self, config: build) -> pathlib.Path:
         # for clarity, the name of the dashboard file will follow the same convention
         # as we use for detections, prefixing it with app_name -
-        filename = f"{self.label(config)}.xml"
+        if self.file_path is None:
+            raise FileNotFoundError(
+                f"Dashboard {self.name} file_path was None. Dashboards must be backed by a file."
+            )
+        filename = f"{self.file_path.stem}.xml"
         return pathlib.Path("default/data/ui/views") / filename
 
     def writeDashboardFile(self, j2_env: Environment, config: build):

--- a/contentctl/templates/app_template/default/data/ui/nav/default.xml
+++ b/contentctl/templates/app_template/default/data/ui/nav/default.xml
@@ -2,6 +2,6 @@
   <view name="escu_summary" default="true"/>
   <view name="search"/>
   <collection label="Dashboards">
-    <view source="unclassified" match=" - "/>
+    <view source="unclassified" match="__"/>
   </collection>
 </nav>


### PR DESCRIPTION
we must go back to using the file path. per appinspect, filenames are not permitted to have spaces.