### PR TITLE
Improve YML parsing error output

### DIFF
--- a/contentctl/input/yml_reader.py
+++ b/contentctl/input/yml_reader.py
@@ -11,43 +11,50 @@ class YmlReader:
         add_fields: bool = True,
         STRICT_YML_CHECKING: bool = False,
     ) -> Dict[str, Any]:
-        try:
+        try: 
             file_handler = open(file_path, "r", encoding="utf-8")
+        except OSError as exc:
+            print(f"\nThere was an unrecoverable error when opening the file '{file_path}' - we will exit immediately:\n{str(exc)}")
+            sys.exit(1)
 
+            
+        
             # The following code can help diagnose issues with duplicate keys or
             # poorly-formatted but still "compliant" YML.  This code should be
             # enabled manually for debugging purposes. As such, strictyaml
             # library is intentionally excluded from the contentctl requirements
 
+        
+        try:
             if STRICT_YML_CHECKING:
+                # This is an extra level of verbose parsing that can be
+                # enabled for debugging purpose. It is intentionally done in
+                # addition to the regular yml parsing
                 import strictyaml
-
-                try:
-                    strictyaml.dirty_load(file_handler.read(), allow_flow_style=True)
-                    file_handler.seek(0)
-                except Exception as e:
-                    print(f"Error loading YML file {file_path}: {str(e)}")
-                    sys.exit(1)
-            try:
-                # Ideally we should use
-                # from contentctl.actions.new_content import NewContent
-                # and use NewContent.UPDATE_PREFIX,
-                # but there is a circular dependency right now which makes that difficult.
-                # We have instead hardcoded UPDATE_PREFIX
-                UPDATE_PREFIX = "__UPDATE__"
-                data = file_handler.read()
-                if UPDATE_PREFIX in data:
-                    raise Exception(
-                        f"The file {file_path} contains the value '{UPDATE_PREFIX}'. Please fill out any unpopulated fields as required."
-                    )
-                yml_obj = yaml.load(data, Loader=yaml.CSafeLoader)
-            except yaml.YAMLError as exc:
-                print(exc)
+                strictyaml.dirty_load(file_handler.read(), allow_flow_style=True)
+                file_handler.seek(0)
+            
+                print(f"Error loading YML file {file_path}: {str(e)}")
                 sys.exit(1)
 
-        except OSError as exc:
-            print(exc)
+            
+            # Ideally we should use
+            # from contentctl.actions.new_content import NewContent
+            # and use NewContent.UPDATE_PREFIX,
+            # but there is a circular dependency right now which makes that difficult.
+            # We have instead hardcoded UPDATE_PREFIX
+            UPDATE_PREFIX = "__UPDATE__"
+            data = file_handler.read()
+            if UPDATE_PREFIX in data:
+                raise Exception(
+                    f"\nThe file {file_path} contains the value '{UPDATE_PREFIX}'. Please fill out any unpopulated fields as required."
+                )
+            yml_obj = yaml.load(data, Loader=yaml.CSafeLoader)
+
+        except yaml.YAMLError as exc:
+            print(f"\nThere was an unrecoverable YML Parsing error when reading or parsing the file '{file_path}' - we will exit immediately:\n{str(exc)}")
             sys.exit(1)
+
 
         if add_fields is False:
             return yml_obj


### PR DESCRIPTION
Give the name of the YML file which causes an exception when there is an error parsing a yml file. Right now we do not, which makes debugging and fixing the error needlessly complicated


For example, instead of crashing, we will give the most verbose error we can. For example, this is the result of trying to parse an invalid YML now
<img width="1444" alt="image" src="https://github.com/user-attachments/assets/4580dafb-ce6b-4969-8fc1-0bc9261180bb" />

Unfortunately, we can't give a more detailed error than this, or recommendation of what to fix, but this is typically enough that when the file is opened, especially in an IDE with YML support, it is clear what the issue is.