### PR TITLE
Enable Attack Data Download before Test

### DIFF
--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -200,6 +200,7 @@ class Director:
                         context={
                             "output_dto": self.output_dto,
                             "app": self.input_dto.app,
+                            "config": self.input_dto,
                         },
                     )
                     self.output_dto.addContentToDictMappings(detection)

--- a/contentctl/objects/config.py
+++ b/contentctl/objects/config.py
@@ -318,6 +318,7 @@ class validate(Config_Base):
         for cache in self.test_data_caches:
             root_folder_path = self.external_repos_path / cache.root_folder_name
             # See if this data file was in that path
+
             if str(filename).startswith(cache.prefix):
                 new_file_name = str(filename).replace(cache.prefix, "")
                 new_file_path = root_folder_path / new_file_name
@@ -336,7 +337,7 @@ class validate(Config_Base):
                 return new_file_path
 
         raise ValueError(
-            f"Test data file '{filename}' does not exist in ANY of the following caches.  If you are supplying caches, any HTTP file MUST be located in a cache: [{[cache.prefix for cache in self.test_data_caches]}]"
+            f"Test data file '{filename}' does not exist in ANY of the following caches. If you are supplying caches, any HTTP file MUST be located in a cache: [{[cache.root_folder_name for cache in self.test_data_caches]}]"
         )
 
     @property

--- a/contentctl/objects/test_attack_data.py
+++ b/contentctl/objects/test_attack_data.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
-from pydantic import BaseModel, HttpUrl, FilePath, Field, ConfigDict
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from contentctl.objects.config import validate
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FilePath,
+    HttpUrl,
+    ValidationInfo,
+    field_validator,
+)
 
 
 class TestAttackData(BaseModel):
@@ -11,3 +25,24 @@ class TestAttackData(BaseModel):
     sourcetype: str = Field(...)
     custom_index: str | None = None
     host: str | None = None
+
+    @field_validator("data", mode="after")
+    @classmethod
+    def check_for_existence_of_attack_data_repo(
+        cls, value: HttpUrl | FilePath, info: ValidationInfo
+    ) -> HttpUrl | FilePath:
+        # this appears to be called more than once, the first time
+        # info.context is always None. In this case, just return what
+        # was passed.
+        if not info.context:
+            return value
+
+        # When the config is passed, used it to determine if we can map
+        # the test data to a file on disk
+        if info.context.get("config", None):
+            config: validate = info.context.get("config", None)
+            return config.map_to_attack_data_cache(value)
+        else:
+            raise ValueError(
+                "config not passed to TestAttackData constructor in context"
+            )


### PR DESCRIPTION
If attack_data repo exists, then
use it instead. otherwise, or
if the file is not found in the
repo, default to a download.

If the file is not found, but we SHOULD have found it, we throw an error at validate time.

This PR supersedes the previous attempt at this implementation:
https://github.com/splunk/contentctl/pull/374