### PR TITLE
fixes #394, adds action.email to email output

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -73,6 +73,7 @@ action.notable.param.severity = high
 {% endif %}
 {% endif %}
 {% if detection.deployment.alert_action.email %}
+action.email = 1
 action.email.subject.alert = {{ detection.deployment.alert_action.email.subject | custom_jinja2_enrichment_filter(detection) | escapeNewlines() }}
 action.email.to = {{ detection.deployment.alert_action.email.to }}
 action.email.message.alert = {{ detection.deployment.alert_action.email.message | custom_jinja2_enrichment_filter(detection) | escapeNewlines() }}


### PR DESCRIPTION
Closes #394 

Adds `action.email = 1` to the output of the email part of the detections template.