### PR TITLE
Issue template update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Create a report to help us improve contentctl
 title: "[BUG]"
 labels: bug
 assignees: ''
+type: Bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,7 @@ about: Create a report to help us improve contentctl
 title: "[BUG]"
 labels: bug
 assignees: ''
-type: Bug
+type: "Bug"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
+type: "Feature"
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
Issue Types have made it out of Public Preview: https://github.blog/changelog/2025-04-09-evolving-github-issues-and-projects/

