### PR TITLE
Fix runtime csv testing error

### DIFF
--- a/contentctl/actions/detection_testing/GitService.py
+++ b/contentctl/actions/detection_testing/GitService.py
@@ -14,7 +14,7 @@ from contentctl.input.director import DirectorOutputDto
 from contentctl.objects.config import All, Changes, Selected, test_common
 from contentctl.objects.data_source import DataSource
 from contentctl.objects.detection import Detection
-from contentctl.objects.lookup import CSVLookup, Lookup
+from contentctl.objects.lookup import CSVLookup, Lookup, RuntimeCSV
 from contentctl.objects.macro import Macro
 from contentctl.objects.security_content_object import SecurityContentObject
 
@@ -148,6 +148,9 @@ class GitService(BaseModel):
                             matched = list(
                                 filter(
                                     lambda x: isinstance(x, CSVLookup)
+                                    and not isinstance(
+                                        x, RuntimeCSV
+                                    )  # RuntimeCSV is not used directly by any content
                                     and x.filename == decoded_path,
                                     self.director.lookups,
                                 )

--- a/contentctl/actions/validate.py
+++ b/contentctl/actions/validate.py
@@ -54,7 +54,7 @@ class Validate:
         """
         lookupsDirectory = repo_path / "lookups"
 
-        # Get all of the files referneced by Lookups
+        # Get all of the files referenced by Lookups
         usedLookupFiles: list[pathlib.Path] = [
             lookup.filename
             for lookup in director_output_dto.lookups

--- a/contentctl/objects/abstract_security_content_objects/detection_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/detection_abstract.py
@@ -547,7 +547,7 @@ class Detection_Abstract(SecurityContentObject):
                     {
                         "name": lookup.name,
                         "description": lookup.description,
-                        "filename": lookup.filename.name,
+                        "filename": lookup.filename.name,  # This does not cause an issue for RuntimeCSV type because they are not used by any detections
                         "default_match": lookup.default_match,
                         "case_sensitive_match": "true"
                         if lookup.case_sensitive_match

--- a/contentctl/objects/lookup.py
+++ b/contentctl/objects/lookup.py
@@ -257,7 +257,7 @@ class CSVLookup(FileBackedLookup):
         """
         if self.file_path is None:
             raise ValueError(
-                f"Cannot get the filename of the lookup {self.lookup_type} because the YML file_path attribute is None"
+                f"Cannot get the filename of the lookup {self.lookup_type} for content [{self.name}] because the YML file_path attribute is None"
             )  # type: ignore
 
         csv_file = self.file_path.parent / f"{self.file_path.stem}.{self.lookup_type}"  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.3.0"
+version = "5.3.1"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
testing with `contentctl test mode:changes ...` would fail due to the presence of the new RuntimeCSV type.
The code was checking for the filename of a RuntimeCSV Lookup, however this does not exist and is set to None, since it exists only at runtime.

Now, we just exclude instances of RuntimeCSV from the mode:changes checking to see what needs to be tested.