### PR TITLE
New type of version bumping error

### DIFF
--- a/contentctl/objects/errors.py
+++ b/contentctl/objects/errors.py
@@ -185,7 +185,7 @@ class VersionBumpingError(VersioningError):
         return (
             f"Rule '{self.rule_name}' has changed in current build compared to previous "
             "build (stanza hashes differ); the detection version should be bumped "
-            f"to at least {self.previous_version + 1}."
+            f"to {self.previous_version + 1}."
         )
 
     @property
@@ -194,4 +194,30 @@ class VersionBumpingError(VersioningError):
         A short-form error message
         :returns: a str, the message
         """
-        return f"Detection version in current build should be bumped to at least {self.previous_version + 1}."
+        return f"Detection version in current build should be bumped to {self.previous_version + 1}."
+
+
+class VersionBumpingTooFarError(VersioningError):
+    """
+    An error indicating the detection changed but its version was bumped too far
+    """
+
+    @property
+    def long_message(self) -> str:
+        """
+        A long-form error message
+        :returns: a str, the message
+        """
+        return (
+            f"Rule '{self.rule_name}' has changed in current build compared to previous "
+            "build (stanza hashes differ); however the detection version increased too much"
+            f"The version should be reduced to {self.previous_version + 1}."
+        )
+
+    @property
+    def short_message(self) -> str:
+        """
+        A short-form error message
+        :returns: a str, the message
+        """
+        return f"Detection version in current build should be reduced to {self.previous_version + 1}."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.3.1"
+version = "5.3.2"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
We previously checked for versions increasing AT LEAST 1 when there were changes.

This adds a check to ensure that versions do not increase more than 1 between builds, and cleans up the errors to clarify this.