### PR TITLE
New error printout generic case

### DIFF
--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -339,7 +339,7 @@ class Director:
                         error_msg = err.get("msg", "")
                         if "https://errors.pydantic.dev" in error_msg:
                             # Unfortunately, this is a catch-all for untyped errors. We will still need to emit this
-                            # This is harder to read, but the other option is suppressing it which we cannot do as 
+                            # This is harder to read, but the other option is suppressing it which we cannot do as
                             # it makes troubleshooting extremelt difficult
                             print(
                                 f"      {Colors.RED}{Colors.ERROR} {error_msg}{Colors.END}"

--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -338,7 +338,9 @@ class Director:
                     for err in error.errors():
                         error_msg = err.get("msg", "")
                         if "https://errors.pydantic.dev" in error_msg:
-                            continue
+                            # Unfortunately, this is a catch-all for untyped errors. We will still need to emit this
+                            # It will fall through the if/else statement below to the else condition.
+                            pass
 
                         # Clean error categorization
                         if "Field required" in error_msg:

--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -339,11 +339,14 @@ class Director:
                         error_msg = err.get("msg", "")
                         if "https://errors.pydantic.dev" in error_msg:
                             # Unfortunately, this is a catch-all for untyped errors. We will still need to emit this
-                            # It will fall through the if/else statement below to the else condition.
-                            pass
+                            # This is harder to read, but the other option is suppressing it which we cannot do as 
+                            # it makes troubleshooting extremelt difficult
+                            print(
+                                f"      {Colors.RED}{Colors.ERROR} {error_msg}{Colors.END}"
+                            )
 
                         # Clean error categorization
-                        if "Field required" in error_msg:
+                        elif "Field required" in error_msg:
                             print(
                                 f"      {Colors.YELLOW}{Colors.WARNING} Field Required: {err.get('loc', [''])[0]}{Colors.END}"
                             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.4.0"
+version = "5.4.1"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
We were missing printouts of some generic errors, specifically around the tests section.
There isn't much nicer formatting we can apply to this since the message is complex, but we do need to make sure it is emitted.