### PR TITLE
Risk from str to int

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -42,7 +42,7 @@ action.correlationsearch.metadata = {{ detection.metadata | tojson }}
 schedule_window = {{ detection.deployment.scheduling.schedule_window }}
 {% if detection.deployment.alert_action.notable %}
 action.notable = 1
-action.notable.param._entities = [{"risk_object_field": "N/A", "risk_object_type": "N/A", "risk_score": "0"}]
+action.notable.param._entities = [{"risk_object_field": "N/A", "risk_object_type": "N/A", "risk_score": 0}]
 action.notable.param.nes_fields = {{ detection.nes_fields }}
 action.notable.param.rule_description = {{ detection.deployment.alert_action.notable.rule_description | custom_jinja2_enrichment_filter(detection) | escapeNewlines()}}
 action.notable.param.rule_title = {% if detection.type | lower == "correlation" %}RBA: {{ detection.deployment.alert_action.notable.rule_title | custom_jinja2_enrichment_filter(detection) }}{% else %}{{ detection.deployment.alert_action.notable.rule_title | custom_jinja2_enrichment_filter(detection) }}{% endif +%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.5.0"
+version = "5.5.1"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
Change the type of risk_score in _entities in the conf file from str to int.
This PR just removes the quotes to change
`"risk_score": "0"`
to
`"risk_score": 0`
At the dev's request