### PR TITLE
Adding new macro & lookup exceptions

### DIFF
--- a/contentctl/objects/lookup.py
+++ b/contentctl/objects/lookup.py
@@ -65,6 +65,13 @@ LOOKUPS_TO_IGNORE.add(
 # Special case for the Detection "Exploit Public Facing Application via Apache Commons Text"
 LOOKUPS_TO_IGNORE.add("=")
 LOOKUPS_TO_IGNORE.add("other_lookups")
+LOOKUPS_TO_IGNORE.add(
+    "asn_lookup_by_cidr"
+)  # Provided by SA-ThreatIntelligence, part of Enterprise Security
+
+LOOKUPS_TO_IGNORE.add(
+    "mitre_attack_lookup"
+)  # KVStore provided by SA-ThreatIntelligence, part of Enterprise Security
 
 
 class Lookup_Type(StrEnum):

--- a/contentctl/objects/macro.py
+++ b/contentctl/objects/macro.py
@@ -26,6 +26,7 @@ MACROS_TO_IGNORE.add(
 )  # SA-ThreatIntelligence, part of Enterprise Security
 MACROS_TO_IGNORE.add("cim_corporate_web_domain_search")  # Part of CIM/Splunk_SA_CIM
 # MACROS_TO_IGNORE.add("prohibited_processes")
+MACROS_TO_IGNORE.add("globedistance")  # Part of SA-Utils, part of Enterprise Security
 
 
 class Macro(SecurityContentObject):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.5.4"
+version = "5.5.5"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
https://github.com/splunk/security_content/pull/3544/ depends on the use of the `mitre_attack_lookup` lookup provided by ES.

https://github.com/splunk/security_content/pull/3558 depends on the use of the `globedistance()` macro and the `asn_lookup_by_cidr` lookup, both provided by ES.

This stubs them both into the ignore lists- detections will be updated w/ appropriate flags (We should probably have a different state that allows for unit tests to run when ES is present instead of having to default to manual_testing?)