### PR TITLE
Bump MITRE ATT&CK version in output layer

### DIFF
--- a/contentctl/output/attack_nav_output.py
+++ b/contentctl/output/attack_nav_output.py
@@ -88,7 +88,7 @@ class AttackNavOutput:
         layer: LayerData = {
             "name": self.layer_name,
             "versions": {
-                "attack": "14",  # Update as needed
+                "attack": "17",  # Update as needed
                 "navigator": "5.1.0",
                 "layer": "4.5",
             },


### PR DESCRIPTION
Bumping the layer to 17, the version we're currently using.