### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.5.5"
+version = "5.5.6"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]
@@ -28,7 +28,7 @@ semantic-version = "^2.10.0"
 bottle = ">=0.12.25,<0.14.0"
 tqdm = "^4.66.5"
 pygit2 = "^1.15.1"
-tyro = "^0.9.2"
+tyro = "^0.9.2,<0.9.23"
 gitpython = "^3.1.43"
 setuptools = ">=69.5.1,<81.0.0"
 rich = "^14.0.0"


### PR DESCRIPTION
There is a bug in tyro v0.9.23 which prevents parsing a large list of files with the mode:selected --mode.files command. It errors out after parsing more than 530 files - but this is not an issue pre-v0.9.23. At this time, we just pin to that older version