### PR TITLE
Make data_sources lookup case insensitive

### DIFF
--- a/contentctl/input/director.py
+++ b/contentctl/input/director.py
@@ -200,6 +200,7 @@ class Director:
             author=self.input_dto.app.author_name,
             description="A lookup file that contains the data source objects for detections.",
             lookup_type=Lookup_Type.csv,
+            case_sensitive_match=False,
             contents=RuntimeCsvWriter.generateDatasourceCSVContent(
                 self.output_dto.data_sources
             ),


### PR DESCRIPTION
So, casing is weird. Search is _generally_ case insensitive for fields (like sourcetype)- but field extraction based on the sourcetype is **not** necessarily case insensitive. The real example case here for this is `xmlwineventlog` vs `XmlWinEventlog` (or event `xMlWiNeVeNtLoG` if you want to cause pain) - the extractions applied to each one _could_ be different, depending on the version of Splunk, the version of the TA, etc. But _generally_ these are "equivalent-ish". Rather than tell customers that their data of `xmlwineventlog` doesn't satisfy `XmlWinEventLog`, we should probably hope they know their data isn't broken to a considerable degree.  

See TR-4187.