### PR TITLE
Update to add SPLUNK_GENERALTERMS env. variable

### DIFF
--- a/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
+++ b/contentctl/actions/detection_testing/infrastructures/DetectionTestingInfrastructureContainer.py
@@ -90,6 +90,7 @@ class DetectionTestingInfrastructureContainer(DetectionTestingInfrastructure):
         ]
 
         environment = {}
+        environment["SPLUNK_GENERALTERMS"] = "--accept-sgt-current-at-splunk-com"
         environment["SPLUNK_START_ARGS"] = "--accept-license"
         environment["SPLUNK_PASSWORD"] = self.infrastructure.splunk_app_password
         # Files have already been staged by the time that we call this. Files must only be staged


### PR DESCRIPTION
To deploy a the recent Splunk container, it is required to accept the Splunk General Terms.
This can be done by adding the following environment variable to the docker run command:

* SPLUNK_GENERALTERMS=--accept-sgt-current-at-splunk-com
