### PR TITLE
alert.digest_mode should be dynamic

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -69,7 +69,7 @@ action.sendtophantom.param.phantom_server = {{ detection.deployment.alert_action
 action.sendtophantom.param.sensitivity = {{ detection.deployment.alert_action.phantom.sensitivity | custom_jinja2_enrichment_filter(detection) }}
 action.sendtophantom.param.severity = {{ detection.deployment.alert_action.phantom.severity | custom_jinja2_enrichment_filter(detection) }}
 {% endif %}
-alert.digest_mode = 1
+alert.digest_mode = {% if detection.tags.throttling and detection.tags.throttling.fields %}0{% else %}1{% endif +%}
 disabled = {{ (not detection.enabled_by_default) | lower }}
 enableSched = 1
 allow_skew = 100%


### PR DESCRIPTION
As per #445 the value of alert.digest_mode should be 0 when `detection.tags.throttling.fields` are defined.