### PR TITLE
Add action.email.sendcsv param

### DIFF
--- a/contentctl/objects/deployment_email.py
+++ b/contentctl/objects/deployment_email.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -8,3 +10,4 @@ class DeploymentEmail(BaseModel):
     message: str
     subject: str
     to: str
+    sendcsv: Optional[bool] = False

--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -55,6 +55,9 @@ action.email.subject.alert = {{ detection.deployment.alert_action.email.subject 
 action.email.to = {{ detection.deployment.alert_action.email.to }}
 action.email.message.alert = {{ detection.deployment.alert_action.email.message | custom_jinja2_enrichment_filter(detection) | escapeNewlines() }}
 action.email.useNSSubject = 1
+{% if detection.deployment.alert_action.email.sendcsv %}
+action.email.sendcsv = 1
+{% endif %}
 {% endif %}
 {% if detection.deployment.alert_action.slack %}
 action.slack = 1


### PR DESCRIPTION
As per #447, `action.email.sendcsv` will be set to `1` when the `sendcsv` key is defined in the detections's yaml file.