### PR TITLE
Align alert.suppress value

### DIFF
--- a/contentctl/output/templates/savedsearches_detections.j2
+++ b/contentctl/output/templates/savedsearches_detections.j2
@@ -79,7 +79,7 @@ quantity = 0
 realtime_schedule = 0
 is_visible = false
 {% if detection.tags.throttling %}
-alert.suppress = true
+alert.suppress = 1
 alert.suppress.fields = {{ detection.tags.throttling.conf_formatted_fields() }}
 alert.suppress.period = {{ detection.tags.throttling.period }}
 {% endif %}


### PR DESCRIPTION
As per #452 this PR align the value of `alert.suppress` parameter with what the Splunk ES Content Management sets.