### PR TITLE
Add output fields to DS model serialization

### DIFF
--- a/contentctl/objects/data_source.py
+++ b/contentctl/objects/data_source.py
@@ -55,6 +55,7 @@ class DataSource(SecurityContentObject):
             "field_mappings": self.field_mappings,
             "convert_to_log_source": self.convert_to_log_source,
             "example_log": self.example_log,
+            "output_fields": self.output_fields,
         }
 
         # Combine fields from this model with fields from parent


### PR DESCRIPTION
Data Sources may have "output fields" defined. These are not currently included in the model. For TR-4080, these need to be included so the fields are available to the site-gen code.