### PR TITLE
Date cannot be future

### DIFF
--- a/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
@@ -492,7 +492,6 @@ class SecurityContentObject_Abstract(BaseModel, abc.ABC):
         "limitations in Type Checking."
     )
 
-
     @field_validator("date", mode="after")
     @classmethod
     def ensure_date_is_not_in_future(cls, value: datetime.date) -> datetime.date:

--- a/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
+++ b/contentctl/objects/abstract_security_content_objects/security_content_object_abstract.py
@@ -492,6 +492,26 @@ class SecurityContentObject_Abstract(BaseModel, abc.ABC):
         "limitations in Type Checking."
     )
 
+
+    @field_validator("date", mode="after")
+    @classmethod
+    def ensure_date_is_not_in_future(cls, value: datetime.date) -> datetime.date:
+        """Ensure that the date is not in the future.
+        Args:
+            value (datetime.date): The date of the content, read from the YML.
+        Raises:
+            ValueError: The date of the content is in the future.
+        Returns:
+            datetime.date: The validated date of the content, read from the YML.
+        """
+        todays_date = datetime.datetime.now(datetime.UTC).date()
+        if value > todays_date:
+            raise ValueError(
+                f"Content date [{value}], is in the future. The date of content must be today ({todays_date}) or earlier. "
+                "Note that this date is relative to UTC, not your current locale."
+            )
+        return value
+
     def checkDeprecationInfo(
         self, app: CustomApp, deprecation_info: DeprecationInfoInFile | None
     ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.5.14"
+version = "5.5.15"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
Generate an error during content validation if the date is set for the future.
Note that this is relative to UTC, so there are some minor edge cases where this generates an exception based on the locale of a developer.  This is documented in the error message returned however.

Note this is what the new check shows on our repo today, in which a piece of content accidentally has a future date:
<img width="2310" height="812" alt="image" src="https://github.com/user-attachments/assets/6e9645f0-301d-4e09-b14f-f45c624e63a9" />
