### PR TITLE
Tweak suffixes

### DIFF
--- a/contentctl/helper/splunk_app.py
+++ b/contentctl/helper/splunk_app.py
@@ -385,7 +385,7 @@ class SplunkApp:
 
                 # Validate the filename is the expected .tgz file
                 filename = Path(value.strip().strip('"'))
-                if filename.suffixes != [".tgz"]:
+                if filename.suffixes != [".tar", ".gz"]:
                     raise ValueError(
                         f"Filename has unexpected extension(s): {filename.suffixes}"
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "contentctl"
 
-version = "5.5.15"
+version = "5.5.16"
 
 description = "Splunk Content Control Tool"
 authors = ["STRT <research@splunk.com>"]


### PR DESCRIPTION
Looks like Splunkbase changed some things, so metadata validation was hitting a ValueError and bailing out. See https://github.com/splunk/security_content/actions/runs/22721988462/job/65886387827?pr=3937 for example.